### PR TITLE
Recognize more file extensions

### DIFF
--- a/guessit/patterns.py
+++ b/guessit/patterns.py
@@ -22,9 +22,9 @@
 
 subtitle_exts = [ 'srt', 'idx', 'sub', 'ssa', 'txt' ]
 
-video_exts = ['3g2', '3gp', '3gp2', 'asf', 'avi', 'flv', 'mk2', 'mka', 'mkv',
-              'mov', 'mp4', 'mp4', 'mp4a', 'mpeg', 'mpg', 'ogg', 'ogm', 'ogv',
-              'qt', 'ra', 'ram', 'rm', 'ts', 'wav', 'webm', 'wma', 'wmv']
+video_exts = ['3g2', '3gp', '3gp2', 'asf', 'avi', 'divx', 'flv', 'm4v', 'mk2',
+              'mka', 'mkv', 'mov', 'mp4', 'mp4a', 'mpeg', 'mpg', 'ogg', 'ogm',
+              'ogv', 'qt', 'ra', 'ram', 'rm', 'ts', 'wav', 'webm', 'wma', 'wmv']
 
 group_delimiters = [ '()', '[]', '{}' ]
 


### PR DESCRIPTION
I'm using enzyme to parse videos, so I updated patterns.py to include all the filename extensions that it can recognize.
