### PR TITLE
Windows shares path will cause fileutils.split_path to loop endlessly

### DIFF
--- a/guessit/fileutils.py
+++ b/guessit/fileutils.py
@@ -18,7 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import ntpath
 import os.path
 import zipfile
 
@@ -46,14 +45,14 @@ def split_path(path):
     """
     result = []
     while True:
-        head, tail = ntpath.split(path)
+        head, tail = os.path.split(path)
 
         # on Unix systems, the root folder is '/'
         if head == '/' and tail == '':
             return ['/'] + result
 
-        # on Windows, the root folder is a drive letter (eg: 'C:\')
-        if len(head) == 3 and head[1:] == ':\\' and tail == '':
+        # on Windows, the root folder is a drive letter (eg: 'C:\') or for shares \\
+        if ((len(head) == 3 and head[1:] == ':\\') or (len(head) == 2 and head == '\\\\')) and tail == '':
             return [head] + result
 
         if head == '' and tail == '':


### PR DESCRIPTION
When giving the fileutils.split_path a path that points to a windows share file `\\share\folder\file.avi` for example. It will loop endlessly because it never returns.
This should fix that.

Also a small cleanup of the 'ntpath' as it gives import errors on some systems, use os.path instead.
