### PR TITLE
Revise setup.py to enable install of guessit CLI

### DIFF
--- a/guessit/__main__.py
+++ b/guessit/__main__.py
@@ -80,7 +80,7 @@ def run_demo(episodes=True, movies=True):
             detect_filename(f, filetype = 'movie')
 
 
-if __name__ == '__main__':
+def main():
     slogging.setupLogging()
 
     parser = OptionParser(usage = 'usage: %prog [options] file1 [file2...]')
@@ -110,3 +110,6 @@ if __name__ == '__main__':
 
         else:
             parser.print_help()
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,17 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 NEWS = open(os.path.join(here, 'NEWS.rst')).read()
 
+
+requires = []
+
+
+entry_points = {
+    'console_scripts' : [
+        'guessit = guessit.__main__:main'
+    ]
+}
+
+
 args = dict(name = 'guessit',
             version = guessit.__version__,
             description = 'GuessIt - a library for guessing information from video files.',
@@ -52,7 +63,8 @@ args = dict(name = 'guessit',
             license = 'LGPLv3',
             packages = [ 'guessit', 'guessit.transfo' ],
             include_package_data=True,
-            install_requires = [],
+            install_requires = requires,
+            entry_points=entry_points,
             extras_require = { 'language_detection':  ['guess-language>=0.2'] }
             )
 


### PR DESCRIPTION
These revisions enable **python setup.py install** to place a CLI of **guessit** to the system's default Python CLI directory (e.g. **/usr/local/share/python/** on OSX with Python installed via Homebrew). As a result, a user can simply issue the command **guessit** instead of the current **python guessit.py**.

**NOTE**: these revisions do not alter the code base itself, but instead move **guessit.py** from the root folder to **guessit/**main**.py** and enable the install of the **guessit** CLI using the **entry_points** arg in **setup.py**.
