### PR TITLE
Added support for nfo files

### DIFF
--- a/docs/user/python.rst
+++ b/docs/user/python.rst
@@ -8,7 +8,8 @@ The main entry points to the python module are the ``guess_video_info``,
 ``guess_movie_info`` and ``guess_episode_info``.
 
 The ``guess_video_info`` function will try to autodetect the type of the
-file, either movie, moviesubtitle, episode or episodesubtitle.
+file, either movie, moviesubtitle, movieinfo, episode, episodesubtitle or
+episodeinfo.
 
 Pass them the filename and the desired information type:
 

--- a/guessit/matcher.py
+++ b/guessit/matcher.py
@@ -38,7 +38,8 @@ class IterativeMatcher(object):
         a movie.
 
         The recognized 'filetype' values are:
-        [ autodetect, subtitle, movie, moviesubtitle, episode, episodesubtitle ]
+        [ autodetect, subtitle, info, movie, moviesubtitle, movieinfo, episode,
+        episodesubtitle, episodeinfo ]
 
 
         The IterativeMatcher works mainly in 2 steps:
@@ -67,9 +68,9 @@ class IterativeMatcher(object):
         resolution when they arise.
         """
 
-        valid_filetypes = ('autodetect', 'subtitle', 'video',
-                           'movie', 'moviesubtitle',
-                           'episode', 'episodesubtitle')
+        valid_filetypes = ('autodetect', 'subtitle', 'info', 'video',
+                           'movie', 'moviesubtitle', 'movieinfo',
+                           'episode', 'episodesubtitle', 'episodeinfo')
         if filetype not in valid_filetypes:
             raise ValueError("filetype needs to be one of %s" % valid_filetypes)
         if not PY3 and not isinstance(filename, unicode):
@@ -116,7 +117,7 @@ class IterativeMatcher(object):
         #       - language before episodes_rexps
         #       - properties before language (eg: he-aac vs hebrew)
         #       - release_group before properties (eg: XviD-?? vs xvid)
-        if mtree.guess['type'] in ('episode', 'episodesubtitle'):
+        if mtree.guess['type'] in ('episode', 'episodesubtitle', 'episodeinfo'):
             strategy = [ 'guess_date', 'guess_website', 'guess_release_group',
                          'guess_properties', 'guess_language',
                          'guess_video_rexps',
@@ -148,7 +149,7 @@ class IterativeMatcher(object):
 
         # 5- try to identify the remaining unknown groups by looking at their
         #    position relative to other known elements
-        if mtree.guess['type'] in ('episode', 'episodesubtitle'):
+        if mtree.guess['type'] in ('episode', 'episodesubtitle', 'episodeinfo'):
             apply_transfo('guess_episode_info_from_position')
         else:
             apply_transfo('guess_movie_title_from_position')

--- a/guessit/patterns.py
+++ b/guessit/patterns.py
@@ -25,6 +25,8 @@ import re
 
 subtitle_exts = [ 'srt', 'idx', 'sub', 'ssa' ]
 
+info_exts = [ 'nfo' ]
+
 video_exts = ['3g2', '3gp', '3gp2', 'asf', 'avi', 'divx', 'flv', 'm4v', 'mk2',
               'mka', 'mkv', 'mov', 'mp4', 'mp4a', 'mpeg', 'mpg', 'ogg', 'ogm',
               'ogv', 'qt', 'ra', 'ram', 'rm', 'ts', 'wav', 'webm', 'wma', 'wmv']

--- a/guessit/test/autodetect.yaml
+++ b/guessit/test/autodetect.yaml
@@ -162,3 +162,15 @@
   videoCodec: h264
   releaseGroup: PublicHD
   audioChannels: "5.1"
+
+? Hostages.S01E01.Pilot.for.Air.720p.WEB-DL.DD5.1.H.264-NTb.nfo
+: type: episodeinfo
+  series: Hostages
+  title: Pilot for Air
+  season: 1
+  episodeNumber: 1
+
+? Despicable.Me.2.2013.1080p.BluRay.x264-VeDeTT.nfo
+: type: movieinfo
+  title: Despicable Me 2
+  year: 2013

--- a/guessit/transfo/guess_filetype.py
+++ b/guessit/transfo/guess_filetype.py
@@ -20,7 +20,7 @@
 
 from __future__ import unicode_literals
 from guessit import Guess
-from guessit.patterns import (subtitle_exts, video_exts, episode_rexps,
+from guessit.patterns import (subtitle_exts, info_exts, video_exts, episode_rexps,
                               find_properties, compute_canonical_form)
 from guessit.date import valid_year
 from guessit.textutils import clean_string
@@ -53,12 +53,16 @@ def guess_filetype(mtree, filetype):
             filetype_container[0] = 'episode'
         elif filetype_container[0] == 'subtitle':
             filetype_container[0] = 'episodesubtitle'
+        elif filetype_container[0] == 'info':
+            filetype_container[0] = 'episodeinfo'
 
     def upgrade_movie():
         if filetype_container[0] == 'video':
             filetype_container[0] = 'movie'
         elif filetype_container[0] == 'subtitle':
             filetype_container[0] = 'moviesubtitle'
+        elif filetype_container[0] == 'info':
+            filetype_container[0] = 'movieinfo'
 
     def upgrade_subtitle():
         if 'movie' in filetype_container[0]:
@@ -67,6 +71,14 @@ def guess_filetype(mtree, filetype):
             filetype_container[0] = 'episodesubtitle'
         else:
             filetype_container[0] = 'subtitle'
+
+    def upgrade_info():
+        if 'movie' in filetype_container[0]:
+            filetype_container[0] = 'movieinfo'
+        elif 'episode' in filetype_container[0]:
+            filetype_container[0] = 'episodeinfo'
+        else:
+            filetype_container[0] = 'info'
 
     def upgrade(type='unknown'):
         if filetype_container[0] == 'autodetect':
@@ -77,6 +89,9 @@ def guess_filetype(mtree, filetype):
     fileext = os.path.splitext(filename)[1][1:].lower()
     if fileext in subtitle_exts:
         upgrade_subtitle()
+        other = { 'container': fileext }
+    elif fileext in info_exts:
+        upgrade_info()
         other = { 'container': fileext }
     elif fileext in video_exts:
         upgrade(type='video')
@@ -112,7 +127,7 @@ def guess_filetype(mtree, filetype):
             upgrade_episode()
 
     # now look whether there are some specific hints for episode vs movie
-    if filetype_container[0] in ('video', 'subtitle'):
+    if filetype_container[0] in ('video', 'subtitle', 'info'):
         # if we have an episode_rexp (eg: s02e13), it is an episode
         for rexp, _, _ in episode_rexps:
             match = re.search(rexp, filename, re.IGNORECASE)


### PR DESCRIPTION
Added support for nfo files. The implementation follows the subtitles pattern and upgrade process for movies and episodes for guess object enrichment: movieinfo and episodeinfo.

Documentation and autodetect YAML configuration for unit tests has been updated.
