### PR TITLE
Workaround for http://bugs.python.org/issue2128

### DIFF
--- a/guessit/__main__.py
+++ b/guessit/__main__.py
@@ -24,6 +24,9 @@ from guessit import u
 from guessit import slogging, guess_file_info
 from optparse import OptionParser
 import logging
+import sys
+import os
+import locale
 
 
 def detect_filename(filename, filetype, info=['filename']):
@@ -83,6 +86,11 @@ def run_demo(episodes=True, movies=True):
 def main():
     slogging.setupLogging()
 
+    # see http://bugs.python.org/issue2128
+    if sys.version_info.major < 3 and os.name == 'nt':        
+        for i, a in enumerate(sys.argv):
+            sys.argv[i] = a.decode(locale.getpreferredencoding())
+        
     parser = OptionParser(usage = 'usage: %prog [options] file1 [file2...]')
     parser.add_option('-v', '--verbose', action='store_true', dest='verbose', default=False,
                       help = 'display debug output')


### PR DESCRIPTION
There is bug in python 2.x on windows. sys.argv on windows can't retrieve unicode strings (see http://bugs.python.org/issue2128). It won't be fix on 2.x, so workaround is the only solution.

```
D:\devel\workspace\guessit>python -m guessit "é.avi"
Traceback (most recent call last):
  File "D:\Python\Python27\lib\runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "D:\Python\Python27\lib\runpy.py", line 72, in _run_code
    exec code in run_globals
  File "D:\devel\workspace\guessit\guessit\__main__.py", line 115, in <module>
    main()
  File "D:\devel\workspace\guessit\guessit\__main__.py", line 109, in main
    info = options.info.split(','))
  File "D:\devel\workspace\guessit\guessit\__main__.py", line 30, in detect_filename
    filename = u(filename)
  File "guessit\__init__.py", line 56, in u
    return x.decode('utf-8')
  File "D:\Python\Python27\lib\encodings\utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0xe9 in position 0: invalid continuation byte
```

After the fix

```
D:\devel\workspace\guessit>python -m guessit "é.avi"
For: é.avi
GuessIt found: {
    [1.00] "mimetype": "video/x-msvideo",
    [1.00] "type": "movie",
    [1.00] "container": "avi",
    [0.60] "title": "\u00e9"
}
```
