### PR TITLE
Add comma as a property separator

### DIFF
--- a/guessit/patterns.py
+++ b/guessit/patterns.py
@@ -34,7 +34,7 @@ video_exts = ['3g2', '3gp', '3gp2', 'asf', 'avi', 'divx', 'flv', 'm4v', 'mk2',
 group_delimiters = [ '()', '[]', '{}' ]
 
 # separator character regexp
-sep = r'[][)(}{+ /\._-]' # regexp art, hehe :D
+sep = r'[][,)(}{+ /\._-]' # regexp art, hehe :D
 
 # character used to represent a deleted char (when matching groups)
 deleted = '_'


### PR DESCRIPTION
This was not working.

```
For: Howl's_Moving_Castle_(2004)_[720p,HDTV,x264,DTS]-FlexGet.avi
GuessIt found: {
    [1.00] "mimetype": "video/x-msvideo",
    [1.00] "type": "movie",
    [0.60] "title": "Howl's Moving Castle",
    [1.00] "container": "avi",
    [1.00] "year": 2004
}
```

After the fix:

```
For: Howl's_Moving_Castle_(2004)_[720p,HDTV,x264,DTS]-FlexGet.avi
GuessIt found: {
    [1.00] "mimetype": "video/x-msvideo",
    [1.00] "videoCodec": "h264",
    [1.00] "container": "avi",
    [1.00] "format": "HDTV",
    [0.60] "title": "Howl's Moving Castle",
    [1.00] "screenSize": "720p",
    [1.00] "year": 2004,
    [1.00] "type": "movie",
    [1.00] "audioCodec": "DTS"
}
```
