### PR TITLE
Added '.ass' subtitle extension

### DIFF
--- a/guessit/patterns/extension.py
+++ b/guessit/patterns/extension.py
@@ -22,7 +22,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-subtitle_exts = ['srt', 'idx', 'sub', 'ssa']
+subtitle_exts = ['srt', 'idx', 'sub', 'ssa', 'ass']
 
 info_exts = ['nfo']
 


### PR DESCRIPTION
This subtitle extension is missing. Without this being defined, a subtitle with .ass extension, will be guessed as 
`'type': 'episode'`
instead of 
`'type': 'episodesubtitle'`
