### PR TITLE
Fix subtitle language detection when using subtitle_suffixes

### DIFF
--- a/guessit/rules/properties/language.py
+++ b/guessit/rules/properties/language.py
@@ -136,7 +136,7 @@ def find_languages(string, context=None):
                 key = 'subtitle_language'
         for suffix in subtitle_suffixes:
             if lang_word.endswith(suffix):
-                lang_word = lang_word[:len(suffix) - 1]
+                lang_word = lang_word[:len(lang_word) - len(suffix)]
                 key = 'subtitle_language'
         for prefix in lang_prefixes:
             if lang_word.startswith(prefix):

--- a/guessit/test/rules/language.yml
+++ b/guessit/test/rules/language.yml
@@ -17,6 +17,8 @@
 ? ENG.-.FR Sub
 ? +ENG.-.SubFR
 ? +ENG.-.FRSUB
+? +ENG.-.FRSUBS
+? +ENG.-.FR-SUBS
 : language: English
   subtitle_language: French
 
@@ -24,3 +26,14 @@
 ? "Le.Prestige[x264.{Fr-Eng}.St{Fr-Eng}.Chaps].mkv"
 : language: [French, English]
   subtitle_language: [French, English]
+
+? +ENG.-.sub.SWE
+? ENG.-.SWE Sub
+? +ENG.-.SubSWE
+? +ENG.-.SWESUB
+? +ENG.-.sub.SV
+? ENG.-.SV Sub
+? +ENG.-.SubSV
+? +ENG.-.SVSUB
+: language: English
+  subtitle_language: Swedish


### PR DESCRIPTION
The split for `lang_word` was wrong and certain subtitle languages were not detected or they were wrongly detected.

2 letter language codes only worked with 3 letter suffixes and 3 letter language codes only worked with 4 letter suffixes

Previously not working examples
- FRSUBS: not detected. Resulting language code after split was FRS
- SWESUB: Wrongly detected. Resulting language code was SW, therefore the wrong language was detected.
