### PR TITLE
Fix for #357: Episode is not detected in a less relevant filepart

### DIFF
--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -409,8 +409,13 @@ class RemoveWeakIfSxxExx(Rule):
     consequence = RemoveMatch
 
     def when(self, matches, context):
-        if matches.tagged('SxxExx', lambda match: not match.private):
-            return matches.tagged('weak-movie')
+        to_remove = []
+        for filepart in matches.markers.named('path'):
+            if matches.range(filepart.start, filepart.end,
+                             predicate=lambda match: not match.private and 'SxxExx' in match.tags):
+                to_remove.extend(matches.range(
+                    filepart.start, filepart.end, predicate=lambda match: 'weak-movie' in match.tags))
+        return to_remove
 
 
 class RemoveWeakDuplicate(Rule):

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2191,3 +2191,16 @@
   type: episode
   video_codec: h265
   website: www.site.com
+
+? Show.Name.S01.720p.HDTV.DD5.1.x264-Group/show.name.0106.720p-group.mkv
+: title: Show Name
+  season: 1
+  screen_size: 720p
+  format: HDTV
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  release_group: Group
+  episode: 6
+  container: mkv
+  type: episode


### PR DESCRIPTION
This fixes an issue (#357) where episode is not detected when the most relevant filepart contains only season (e.g: S01) and another filepart contains season and episode in SSEE format (e.g.: 0106)

 