### PR TITLE
Strip separators from matches

### DIFF
--- a/guessit/rules/common/__init__.py
+++ b/guessit/rules/common/__init__.py
@@ -6,6 +6,7 @@ Common module
 import re
 
 seps = r' [](){}+*|=-_~#/\\.,;:'  # list of tags/words separators
+seps_no_groups = seps.replace('[](){}', '')
 seps_no_fs = seps.replace('/', '').replace('\\', '')
 
 title_seps = r'-+/\|'  # separators for title

--- a/guessit/rules/properties/container.py
+++ b/guessit/rules/properties/container.py
@@ -6,6 +6,8 @@ container property
 from rebulk.remodule import re
 
 from rebulk import Rebulk
+
+from guessit.rules.common import seps
 from ..common.validators import seps_surround
 from ...reutils import build_or_pattern
 
@@ -18,7 +20,7 @@ def container():
     """
     rebulk = Rebulk().regex_defaults(flags=re.IGNORECASE).string_defaults(ignore_case=True)
     rebulk.defaults(name='container',
-                    formatter=lambda value: value[1:],
+                    formatter=lambda value: value.strip(seps),
                     tags=['extension'],
                     conflict_solver=lambda match, other: other
                     if other.name in ['format', 'video_codec'] or

--- a/guessit/test/rules/processors_test.py
+++ b/guessit/test/rules/processors_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# pylint: disable=no-self-use, pointless-statement, missing-docstring, invalid-name, pointless-string-statement
+
+from rebulk.match import Matches, Match
+
+from guessit.rules.processors import StripSeparators
+
+
+def test_strip_separators():
+    strip_separators = StripSeparators()
+
+    matches = Matches()
+
+    m = Match(3, 11, input_string="pre.ABCDEF.post")
+
+    assert m.raw == '.ABCDEF.'
+    matches.append(m)
+
+    returned_matches = strip_separators.when(matches, None)
+    assert returned_matches == matches
+
+    strip_separators.then(matches, returned_matches, None)
+
+    assert m.raw == 'ABCDEF'
+
+
+def test_strip_separators_keep_acronyms():
+    strip_separators = StripSeparators()
+
+    matches = Matches()
+
+    m = Match(0, 13, input_string=".S.H.I.E.L.D.")
+    m2 = Match(0, 22, input_string=".Agent.Of.S.H.I.E.L.D.")
+
+    assert m.raw == '.S.H.I.E.L.D.'
+    matches.append(m)
+    matches.append(m2)
+
+    returned_matches = strip_separators.when(matches, None)
+    assert returned_matches == matches
+
+    strip_separators.then(matches, returned_matches, None)
+
+    assert m.raw == '.S.H.I.E.L.D.'
+    assert m2.raw == 'Agent.Of.S.H.I.E.L.D.'


### PR DESCRIPTION
This is useful in advanced mode for raw values like title, episode_title and release_group to have separators stripped off.