### PR TITLE
SxxExx pattern should be preferred over weak matches

### DIFF
--- a/guessit/rules/common/comparators.py
+++ b/guessit/rules/common/comparators.py
@@ -18,17 +18,18 @@ def marker_comparator_predicate(match):
            not (match.name == 'container' and 'extension' in match.tags)
 
 
-def marker_weight(matches, marker):
+def marker_weight(matches, marker, predicate):
     """
     Compute the comparator weight of a marker
     :param matches:
     :param marker:
+    :param predicate:
     :return:
     """
-    return len(set(match.name for match in matches.range(*marker.span, predicate=marker_comparator_predicate)))
+    return len(set(match.name for match in matches.range(*marker.span, predicate=predicate)))
 
 
-def marker_comparator(matches, markers):
+def marker_comparator(matches, markers, predicate):
     """
     Builds a comparator that returns markers sorted from the most valuable to the less.
 
@@ -36,6 +37,8 @@ def marker_comparator(matches, markers):
 
     :param matches:
     :type matches:
+    :param markers:
+    :param predicate:
     :return:
     :rtype:
     """
@@ -44,7 +47,7 @@ def marker_comparator(matches, markers):
         """
         The actual comparator function.
         """
-        matches_count = marker_weight(matches, marker2) - marker_weight(matches, marker1)
+        matches_count = marker_weight(matches, marker2, predicate) - marker_weight(matches, marker1, predicate)
         if matches_count:
             return matches_count
         len_diff = len(marker2) - len(marker1)
@@ -55,15 +58,17 @@ def marker_comparator(matches, markers):
     return comparator
 
 
-def marker_sorted(markers, matches):
+def marker_sorted(markers, matches, predicate=marker_comparator_predicate):
     """
     Sort markers from matches, from the most valuable to the less.
 
-    :param fileparts:
-    :type fileparts:
+    :param markers:
+    :type markers:
     :param matches:
     :type matches:
+    :param predicate:
     :return:
     :rtype:
     """
-    return sorted(markers, key=cmp_to_key(marker_comparator(matches, markers)))
+    return sorted(markers, key=cmp_to_key(marker_comparator(matches, markers, predicate=predicate)))
+

--- a/guessit/rules/common/comparators.py
+++ b/guessit/rules/common/comparators.py
@@ -71,4 +71,3 @@ def marker_sorted(markers, matches, predicate=marker_comparator_predicate):
     :rtype:
     """
     return sorted(markers, key=cmp_to_key(marker_comparator(matches, markers, predicate=predicate)))
-

--- a/guessit/rules/processors.py
+++ b/guessit/rules/processors.py
@@ -20,10 +20,6 @@ from .common.words import iter_words
 class EnlargeGroupMatches(CustomRule):
     """
     Enlarge matches that are starting and/or ending group to include brackets in their span.
-    :param matches:
-    :type matches:
-    :return:
-    :rtype:
     """
     priority = PRE_PROCESS
 
@@ -130,12 +126,14 @@ class RemoveAmbiguous(Rule):
 
 class RemoveLessSpecificSeasonEpisode(RemoveAmbiguous):
     """
-    If multiple season/episode matches are found with different values, keep the one in the rightmost filepart.
+    If multiple season/episodes matches are found with different values, keep the one tagged as 'SxxExx' or in the rightmost filepart.
     """
-    def __init__(self):
+    def __init__(self, name):
         super(RemoveLessSpecificSeasonEpisode, self).__init__(
-            sort_function=lambda markers, matches: reversed(markers),
-            predicate=lambda match: match.name in ('episode', 'season'))
+            sort_function=(lambda markers, matches:
+                           marker_sorted(list(reversed(markers)), matches,
+                                         lambda match: match.name == name and 'SxxExx' in match.tags)),
+            predicate=lambda match: match.name == name)
 
 
 def _preferred_string(value1, value2):  # pylint:disable=too-many-return-statements
@@ -233,5 +231,7 @@ def processors():
     :return: Created Rebulk object
     :rtype: Rebulk
     """
-    return Rebulk().rules(EnlargeGroupMatches, EquivalentHoles, RemoveLessSpecificSeasonEpisode,
+    return Rebulk().rules(EnlargeGroupMatches, EquivalentHoles,
+                          RemoveLessSpecificSeasonEpisode('season'),
+                          RemoveLessSpecificSeasonEpisode('episode'),
                           RemoveAmbiguous, SeasonYear, Processors, StripSeparators)

--- a/guessit/rules/processors.py
+++ b/guessit/rules/processors.py
@@ -126,7 +126,8 @@ class RemoveAmbiguous(Rule):
 
 class RemoveLessSpecificSeasonEpisode(RemoveAmbiguous):
     """
-    If multiple season/episodes matches are found with different values, keep the one tagged as 'SxxExx' or in the rightmost filepart.
+    If multiple season/episodes matches are found with different values,
+    keep the one tagged as 'SxxExx' or in the rightmost filepart.
     """
     def __init__(self, name):
         super(RemoveLessSpecificSeasonEpisode, self).__init__(

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2901,3 +2901,16 @@
   video_codec: h264
   release_group: CasStudio
   type: episode
+
+? Zoo.S02E05.1080p.WEB-DL.DD5.1.H.264.HKD/160725_02.mkv
+: title: Zoo
+  season: 2
+  episode: 5
+  screen_size: 1080p
+  format: WEB-DL
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  release_group: HKD
+  container: mkv
+  type: episode

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2942,3 +2942,57 @@
   release_group: BTW
   container: mkv
   type: episode
+
+? Bones.S12E02.The.Brain.In.The.Bot.1080p.WEB-DL.DD5.1.H.264-R2D2/161219_06.mkv
+: title: Bones
+  season: 12
+  episode: 2
+  episode_title: The Brain In The Bot
+  screen_size: 1080p
+  format: WEB-DL
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  release_group: R2D2
+  container: mkv
+  type: episode
+
+? The.Messengers.2015.S01E07.1080p.WEB-DL.DD5.1.H264.Nlsubs-Q/QoQ-sbuSLN.462.H.1.5DD.LD-BEW.p0801.70E10S.5102.sregnesseM.ehT.mkv
+: title: The Messengers
+  year: 2015
+  season: 1
+  episode: 7
+  screen_size: 1080p
+  format: WEB-DL
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  video_codec: h264
+  subtitle_language: nl
+  release_group: Q
+  container: mkv
+  type: episode
+
+? /Finding.Carter.S02E01.Love.the.Way.You.Lie.1080p.WEB-DL.AAC2.0.H.264-NL/LN-462.H.0.2CAA.LD-BEW.p0801.eiL.uoY.yaW.eht.evoL.10E20S.retraC.gnidniF.mkv
+: title: Finding Carter
+  season: 2
+  episode: 1
+  episode_title: Love the Way You Lie
+  screen_size: 1080p
+  format: WEB-DL
+  audio_codec: AAC
+  audio_channels: '2.0'
+  video_codec: h264
+  language: nl
+  container: mkv
+  type: episode
+
+? Mr.Robot.S02E12.1080p.WEB-DL.DD5.1-NL.Subs-Het.Robot.Team.OYM/sbuS LN-1.5DD LD-BEW p0801 21E20S toboR .rM.mkv
+: title: Mr Robot
+  season: 2
+  episode: 12
+  screen_size: 1080p
+  format: WEB-DL
+  audio_codec: DolbyDigital
+  audio_channels: '5.1'
+  release_group: Het.Robot.Team.OYM
+  type: episode

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2914,3 +2914,31 @@
   release_group: HKD
   container: mkv
   type: episode
+
+? We.Bare.Bears.S01E14.Brother.Up.1080p.WEB-DL.AAC2.0.H.264-TVSmash/mxNMuJWeO7PUWCMEwqKSsS6D8Vs9S6V3PHD.mkv
+: title: We Bare Bears
+  season: 1
+  episode: 14
+  episode_title: Brother Up
+  screen_size: 1080p
+  format: WEB-DL
+  audio_codec: AAC
+  audio_channels: '2.0'
+  video_codec: h264
+  release_group: TVSmash
+  container: mkv
+  type: episode
+
+? Beyond.S01E02.Tempus.Fugit.720p.FREE.WEBRip.AAC2.0.x264-BTW/gNWDXow11s7E0X7GTDrZ.mkv
+: title: Beyond
+  season: 1
+  episode: 2
+  episode_title: Tempus Fugit
+  screen_size: 720p
+  format: WEBRip
+  audio_codec: AAC
+  audio_channels: '2.0'
+  video_codec: h264
+  release_group: BTW
+  container: mkv
+  type: episode


### PR DESCRIPTION
Fixes #396

- If multiple season/episodes matches are found with different values, keep the one tagged as 'SxxExx' or in the rightmost filepart.