### PR TITLE
Fix `episode` type detection when series name contains `year` followed by SEE pattern

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ History
 - Make `container` values consistent and always lowercase
 - Fix `--type movie` being ignored for movies that starts with numbers
 - Fix invalid `language` detection due the common words `audio`, `true` and `unknown`
+- Fix `episode` type detection when series name contains `year` followed by SEE pattern
 
 2.1.2 (2017-04-03)
 ------------------

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -3935,3 +3935,13 @@
   release_group: KiNGS
   container: mkv
   type: episode
+
+? Series_name.2005.211.episode.title.avi
+: title: Series name
+  year: 2005
+  season: 2
+  episode: 11
+  episode_title: episode title
+  container: avi
+  mimetype: video/x-msvideo
+  type: episode

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -3943,5 +3943,14 @@
   episode: 11
   episode_title: episode title
   container: avi
-  mimetype: video/x-msvideo
+  type: episode
+
+? the.flash.2014.208.hdtv-lol[ettv].mkv
+: title: the flash
+  year: 2014
+  season: 2
+  episode: 8
+  format: HDTV
+  release_group: lol[ettv]
+  container: mkv
   type: episode


### PR DESCRIPTION
Fixes for #235 and #428