### PR TITLE
Detecting FullHD

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 
 - Add `nzb` as new `container` possible value
 - Add `EAC3` as new `audio_codec` possible value
+- Add `FullHD` as new `other` possible value
 - Dropped python 2.6 support
 - Make `container` values consistent and always lowercase
 - Fix `--type movie` being ignored for movies that starts with numbers

--- a/docs/properties.rst
+++ b/docs/properties.rst
@@ -282,8 +282,8 @@ Other properties
 
   - ``3D``, ``Alternative Cut``, ``AudioFix``, ``Bonus``, ``CC``, ``Classic``, ``Colorized``, ``Complete``,
     ``Converted``, ``Documentary``, ``DDC``, ``DualAudio``, ``East Coast Feed``, ``Extended``, ``Extended Cut``,
-    ``Fansub``, ``Fastsub``, ``Festival``, ``FINAL``, ``Hardcoded Subtitles``, ``HD``, ``HDLight``, ``HQ``, ``HR``,
-    ``Internal``, ``LD``, ``Limited``, ``LiNE``, ``MD``, ``mHD``, ``Mux``, ``NTSC``, ``Open Matte``,
+    ``Fansub``, ``Fastsub``, ``Festival``, ``FINAL``, ``FullHD``, ``Hardcoded Subtitles``, ``HD``, ``HDLight``, ``HQ``,
+    ``HR``, ``Internal``, ``LD``, ``Limited``, ``LiNE``, ``MD``, ``mHD``, ``Mux``, ``NTSC``, ``Open Matte``,
     ``Original Aspect Ratio``, ``OV``, ``PAL``, ``Preair``, ``Proper``, ``PS Vita``, ``R5``, ``Read NFO``,
     ``ReEncoded``, ``Remastered``, ``Remux``, ``Retail``, ``Screener``, ``SECAM``, ``Straight to Video``, ``SyncFix``,
     ``Trailer``, ``UltraHD``, ``Uncensored``, ``Uncut``, ``Unrated``, ``West Coast Feed``, ``WideScreen``, ``XXX``

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -73,6 +73,8 @@ def other():
     rebulk.string('LDTV', value='LD')
     rebulk.string('HD', value='HD', validator=None,
                   tags=['streaming_service.prefix', 'streaming_service.suffix'])
+    rebulk.regex('Full-?HD', 'FHD', value='FullHD', validator=None,
+                 tags=['streaming_service.prefix', 'streaming_service.suffix'])
     rebulk.regex('Ultra-?(?:HD)?', 'UHD', value='UltraHD', validator=None,
                  tags=['streaming_service.prefix', 'streaming_service.suffix'])
 

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -3954,3 +3954,12 @@
   release_group: lol[ettv]
   container: mkv
   type: episode
+
+? "[Despair-Paradise].Kono.Subarashii.Sekai.ni.Shukufuku.wo!.2.-..09.vostfr.FHD"
+: options: -E -t episode
+  release_group: Despair-Paradise
+  title: Kono Subarashii Sekai ni Shukufuku wo! 2
+  episode: 9
+  subtitle_language: fr
+  other: FullHD
+  type: episode

--- a/guessit/test/rules/other.yml
+++ b/guessit/test/rules/other.yml
@@ -87,6 +87,11 @@
 ? HD
 : other: HD
 
+? FHD
+? FullHD
+? Full HD
+: other: FullHD
+
 ? UHD
 ? Ultra
 ? UltraHD


### PR DESCRIPTION
Fix for #432 

`HD` and `UltraHD` was already detected in `other` property.
Adding `FullHD` as well