### PR TITLE
Move edition values from 'other' to 'edition' property

### DIFF
--- a/docs/properties.rst
+++ b/docs/properties.rst
@@ -257,8 +257,9 @@ Other properties
 
   Edition of the movie.
 
-  - ``Collector Edition``, ``Criterion Edition``, ``Deluxe Edition``, ``Director's cut``,  ``Special Edition``,
-    ``Limited Edition``, ``Theatrical Edition``
+  - ``Alternative Cut``, ``Collector Edition``, ``Criterion Edition``, ``Deluxe Edition``, ``Director's Cut``,
+    ``Extended``, ``Festival``, ``Remastered``, ``Special Edition``, ``Limited Edition``, ``Theatrical Edition``,
+    ``Uncensored``, ``Uncut``, ``Unrated``
 
 
 - **film**
@@ -280,11 +281,10 @@ Other properties
 
   Other property will appear under this property.
 
-  - ``3D``, ``Alternative Cut``, ``AudioFix``, ``Bonus``, ``CC``, ``Classic``, ``Colorized``, ``Complete``,
-    ``Converted``, ``Documentary``, ``DDC``, ``DualAudio``, ``East Coast Feed``, ``Extended``, ``Extended Cut``,
-    ``Fansub``, ``Fastsub``, ``Festival``, ``FINAL``, ``FullHD``, ``Hardcoded Subtitles``, ``HD``, ``HDLight``, ``HQ``,
-    ``HR``, ``Internal``, ``LD``, ``Limited``, ``LiNE``, ``MD``, ``mHD``, ``Mux``, ``NTSC``, ``Open Matte``,
-    ``Original Aspect Ratio``, ``OV``, ``PAL``, ``Preair``, ``Proper``, ``PS Vita``, ``R5``, ``Read NFO``,
-    ``ReEncoded``, ``Remastered``, ``Remux``, ``Retail``, ``Screener``, ``SECAM``, ``Straight to Video``, ``SyncFix``,
-    ``Trailer``, ``UltraHD``, ``Uncensored``, ``Uncut``, ``Unrated``, ``West Coast Feed``, ``WideScreen``, ``XXX``
+  - ``3D``, ``AudioFix``, ``Bonus``, ``CC``, ``Classic``, ``Colorized``, ``Complete``, ``Converted``, ``Documentary``,
+    ``DDC``, ``DualAudio``, ``East Coast Feed``, ``Fansub``, ``Fastsub``, ``FINAL``, ``FullHD``,
+    ``Hardcoded Subtitles``, ``HD``, ``HDLight``, ``HQ``, ``HR``, ``Internal``, ``LD``, ``Limited``, ``LiNE``, ``MD``,
+    ``mHD``, ``Mux``, ``NTSC``, ``Open Matte``, ``Original Aspect Ratio``, ``OV``, ``PAL``, ``Preair``, ``Proper``,
+    ``PS Vita``, ``R5``, ``Read NFO``, ``ReEncoded``, ``Remux``, ``Retail``, ``Screener``, ``SECAM``,
+    ``Straight to Video``, ``SyncFix``, ``Trailer``, ``UltraHD``, ``West Coast Feed``, ``WideScreen``, ``XXX``
 

--- a/guessit/rules/properties/edition.py
+++ b/guessit/rules/properties/edition.py
@@ -24,12 +24,18 @@ def edition():
                  conflict_solver=lambda match, other: other
                  if other.name == 'episode_details' and other.value == 'Special'
                  else '__default__')
-    rebulk.string('SE', value='Special Edition', tags='has-neighbor')
+    rebulk.string('se', value='Special Edition', tags='has-neighbor')
     rebulk.regex('criterion-edition', 'edition-criterion', value='Criterion Edition')
     rebulk.regex('deluxe', 'deluxe-edition', 'edition-deluxe', value='Deluxe Edition')
-    rebulk.regex('limited', 'limited-edition', value='Limited Edition')
+    rebulk.regex('limited', 'limited-edition', value='Limited Edition', tags=['has-neighbor', 'release-group-prefix'])
     rebulk.regex(r'theatrical-cut', r'theatrical-edition', r'theatrical', value='Theatrical Edition')
     rebulk.regex(r"director'?s?-cut", r"director'?s?-cut-edition", r"edition-director'?s?-cut", 'DC',
-                 value="Director's cut")
+                 value="Director's Cut")
+    rebulk.regex('extended', 'extended-?cut', 'extended-?version',
+                 value='Extended', tags=['has-neighbor', 'release-group-prefix'])
+    rebulk.regex('alternat(e|ive)(?:-?Cut)?', value='Alternative Cut', tags=['has-neighbor', 'release-group-prefix'])
+    for value in ('Remastered', 'Uncensored', 'Uncut', 'Unrated'):
+        rebulk.string(value, value=value, tags=['has-neighbor', 'release-group-prefix'])
+    rebulk.string('Festival', value='Festival', tags=['has-neighbor-before', 'has-neighbor-after'])
 
     return rebulk

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -66,7 +66,7 @@ def other():
     rebulk.regex('(?:PS-?)?Vita', value='PS Vita')
 
     for value in (
-            'Screener', 'Remux', 'Remastered', '3D', 'mHD', 'HDLight', 'HQ', 'DDC', 'HR', 'PAL', 'SECAM', 'NTSC',
+            'Screener', 'Remux', '3D', 'mHD', 'HDLight', 'HQ', 'DDC', 'HR', 'PAL', 'SECAM', 'NTSC',
             'CC', 'LD', 'MD', 'XXX'):
         rebulk.string(value, value=value)
 
@@ -78,18 +78,15 @@ def other():
     rebulk.regex('Ultra-?(?:HD)?', 'UHD', value='UltraHD', validator=None,
                  tags=['streaming_service.prefix', 'streaming_service.suffix'])
 
-    for value in ('Limited', 'Complete', 'Classic', 'Unrated', 'LiNE', 'Bonus', 'Trailer', 'FINAL', 'Retail', 'Uncut',
-                  'Extended', 'Extended Cut', 'Colorized', 'Internal', 'Uncensored'):
+    for value in ('Complete', 'Classic', 'LiNE', 'Bonus', 'Trailer', 'FINAL', 'Retail',
+                  'Colorized', 'Internal'):
         rebulk.string(value, value=value, tags=['has-neighbor', 'release-group-prefix'])
-    rebulk.regex('Extended-?version', value='Extended', tags=['has-neighbor', 'release-group-prefix'])
-    rebulk.regex('Alternat(e|ive)(?:-?Cut)?', value='Alternative Cut', tags=['has-neighbor', 'release-group-prefix'])
     rebulk.regex('Read-?NFO', value='Read NFO')
     rebulk.string('CONVERT', value='Converted', tags='has-neighbor')
     rebulk.string('DOCU', value='Documentary', tags='has-neighbor')
     rebulk.string('OM', value='Open Matte', tags='has-neighbor')
     rebulk.string('STV', value='Straight to Video', tags='has-neighbor')
     rebulk.string('OAR', value='Original Aspect Ratio', tags='has-neighbor')
-    rebulk.string('Festival', value='Festival', tags=['has-neighbor-before', 'has-neighbor-after'])
     rebulk.string('Complet', value='Complete', tags=['has-neighbor', 'release-group-prefix'])
 
     for coast in ('East', 'West'):

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -1167,7 +1167,7 @@
   audio_codec: AAC
   date: 2015-07-01
   format: WEBRip
-  other: Extended
+  edition: Extended
   release_group: BTW
   screen_size: 720p
   streaming_service: Comedy Central
@@ -2250,7 +2250,7 @@
 : title: Show Name
   date: 2016-09-28
   episode_title: Nice Title
-  other: Extended
+  edition: Extended
   screen_size: 1080p
   streaming_service: Comedy Central
   format: WEBRip
@@ -3662,7 +3662,7 @@
   season: 1
   episode: 1
   episode_title: Spark of Rebellion
-  other: Alternative Cut
+  edition: Alternative Cut
   format: HDTV
   video_codec: h264
   release_group: W4F
@@ -3758,7 +3758,7 @@
 ? Rick and Morty Season 1 [UNCENSORED] [BDRip] [1080p] [HEVC]
 : title: Rick and Morty
   season: 1
-  other: Uncensored
+  edition: Uncensored
   format: BluRay
   screen_size: 1080p
   video_codec: h265

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -111,7 +111,7 @@
 ? Movies/Blade Runner (1982)/Blade.Runner.(1982).(Director's.Cut).CD1.DVDRip.XviD.AC3-WAF.avi
 : title: Blade Runner
   year: 1982
-  edition: Director's cut
+  edition: Director's Cut
   cd: 1
   format: DVD
   video_codec: XviD
@@ -147,7 +147,8 @@
   format: DVD
   video_codec: XviD
   release_group: ARROW
-  other: ['Proper', 'Limited']
+  other: Proper
+  edition: Limited Edition
   proper_count: 1
 
 ? Movies/Fr - Paris 2054, Renaissance (2005) - De Christian Volckman - (Film Divx Science Fiction Fantastique Thriller Policier N&B).avi
@@ -363,7 +364,7 @@
   video_codec: h264
   release_group: AN0NYM0US[bb]
   format: BluRay
-  other: Limited
+  edition: Limited Edition
 
 ? movies/La Science des Rêves (2006)/La.Science.Des.Reves.FRENCH.DVDRip.XviD-MP-AceBot.avi
 : title: La Science des Rêves
@@ -688,20 +689,18 @@
 
 ? h265 - HEVC Riddick Unrated Director Cut French 1080p DTS.mkv
 : audio_codec: DTS
-  edition: Director's cut
+  edition: [Unrated, Director's Cut]
   language: fr
   screen_size: 1080p
   title: Riddick
-  other: Unrated
   video_codec: h265
 
 ? "[h265 - HEVC] Riddick Unrated Director Cut French [1080p DTS].mkv"
 : audio_codec: DTS
-  edition: Director's cut
+  edition: [Unrated, Director's Cut]
   language: fr
   screen_size: 1080p
   title: Riddick
-  other: Unrated
   video_codec: h265
 
 ? Barbecue-2014-French-mHD-1080p
@@ -892,7 +891,8 @@
 
 ? Suicide Squad EXTENDED (2016) 2160p 4K UltraHD Blu-Ray x265 (HEVC 10bit BT709) Dolby Atmos 7.1 -DDR
 : title: Suicide Squad
-  other: [Extended, UltraHD]
+  edition: Extended
+  other: UltraHD
   year: 2016
   screen_size: 4K
   format: BluRay
@@ -906,7 +906,7 @@
 ? Queen - A Kind of Magic (Alternative Extended Version) 2CD 2014
 : title: Queen
   alternative_title: A Kind of Magic
-  other: [Alternative Cut, Extended]
+  edition: [Alternative Cut, Extended]
   cd_count: 2
   year: 2014
   type: movie
@@ -914,7 +914,7 @@
 ? Jour.de.Fete.1949.ALTERNATiVE.CUT.1080p.BluRay.x264-SADPANDA[rarbg]
 : title: Jour de Fete
   year: 1949
-  other: Alternative Cut
+  edition: Alternative Cut
   screen_size: 1080p
   format: BluRay
   video_codec: h264
@@ -941,7 +941,7 @@
 
 ? Alien DC (1979) [1080p]
 : title: Alien
-  edition: Director's cut
+  edition: Director's Cut
   year: 1979
   screen_size: 1080p
   type: movie
@@ -949,7 +949,7 @@
 ? Requiem.For.A.Dream.2000.DC.1080p.BluRay.x264.anoXmous
 : title: Requiem For A Dream
   year: 2000
-  edition: Director's cut
+  edition: Director's Cut
   screen_size: 1080p
   format: BluRay
   video_codec: h264
@@ -980,7 +980,7 @@
 ? Suntan.2016.FESTiVAL.DVDRip.x264-IcHoR
 : title: Suntan
   year: 2016
-  other: Festival
+  edition: Festival
   format: DVD
   video_codec: h264
   release_group: IcHoR
@@ -1058,7 +1058,7 @@
 ? The Heartbreak Kid (1993) UNCUT 720p WEBRip x264
 : title: The Heartbreak Kid
   year: 1993
-  other: Uncut
+  edition: Uncut
   screen_size: 720p
   format: WEBRip
   video_codec: h264
@@ -1096,4 +1096,13 @@
   title: 007 Spectre
   format: HDTC
   language: French
+  type: movie
+
+? We.Are.X.2016.LIMITED.BDRip.x264-BiPOLAR
+: title: We Are X
+  year: 2016
+  edition: Limited Edition
+  format: BluRay
+  video_codec: h264
+  release_group: BiPOLAR
   type: movie

--- a/guessit/test/rules/edition.yml
+++ b/guessit/test/rules/edition.yml
@@ -2,7 +2,7 @@
 # Use - marker to check inputs that should not match results.
 ? Director's cut
 ? Edition Director's cut
-: edition: Director's cut
+: edition: Director's Cut
 
 ? Collector
 ? Collector Edition
@@ -23,3 +23,9 @@
 ? Deluxe Edition
 ? Edition Deluxe
 : edition: Deluxe Edition
+
+? Super Movie Alternate XViD
+? Super Movie Alternative XViD
+? Super Movie Alternate Cut XViD
+? Super Movie Alternative Cut XViD
+: edition: Alternative Cut

--- a/guessit/test/rules/other.yml
+++ b/guessit/test/rules/other.yml
@@ -150,11 +150,5 @@
 ? reencoded
 : other: ReEncoded
 
-? Super Movie Alternate XViD
-? Super Movie Alternative XViD
-? Super Movie Alternate Cut XViD
-? Super Movie Alternative Cut XViD
-: other: Alternative Cut
-
 ? CONVERT XViD
 : other: Converted

--- a/guessit/test/various.yml
+++ b/guessit/test/various.yml
@@ -744,7 +744,7 @@
 
 ? Gangs of New York 2002 REMASTERED 1080p BluRay x264-AVCHD
 : format: BluRay
-  other: Remastered
+  edition: Remastered
   screen_size: 1080p
   title: Gangs of New York
   type: movie


### PR DESCRIPTION
This is a proposal to fix #421 

The changes are:
- `Director's cut` value renamed to `Director's Cut` (case fix to be consistent with other values)
- `Alternative Cut`, `Remastered`,  `Festival`, `Uncensored`, `Uncut` and `Unrated` moved from `other` to `edition` property
- `Extended` and `Extended Cut` were merged to `Extended` and moved from `other` to `edition` property

Please feel free to disagree.
