### PR TITLE
Make returned dict structure consistent between CLI and API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,11 +69,11 @@ Usage
 GuessIt can be used from command line::
 
     $ guessit
-    usage: guessit [-h] [-c CONFIG] [-t TYPE] [-n] [-Y] [-D]
-                   [-L ALLOWED_LANGUAGES] [-C ALLOWED_COUNTRIES] [-E]
-                   [-T EXPECTED_TITLE] [-G EXPECTED_GROUP] [-f INPUT_FILE] [-v]
-                   [-P SHOW_PROPERTY] [-a] [-j] [-y] [-p] [-V] [--version]
-                   [filename [filename ...]]
+    usage: guessit [-h] [-t TYPE] [-n] [-Y] [-D] [-L ALLOWED_LANGUAGES]
+          [-C ALLOWED_COUNTRIES] [-E] [-T EXPECTED_TITLE] [-G EXPECTED_GROUP]
+          [-f INPUT_FILE] [-v] [-P SHOW_PROPERTY] [-a] [-1] [-l] [-j] [-y]
+          [-c CONFIG] [--no-embedded-config] [-p] [-V] [--version]
+          [filename [filename ...]]
 
     positional arguments:
       filename              Filename or release name to guess
@@ -82,15 +82,6 @@ GuessIt can be used from command line::
       -h, --help            show this help message and exit
 
     Naming:
-      -c CONFIG, --config CONFIG
-                            Filepath to the configuration file. Configuration
-                            contains the same options as those command line
-                            options, but option names have "-" characters replaced
-                            with "_". If not defined, guessit tries to read a
-                            configuration default configuration file at
-                            ~/.guessit/options.(json|yml|yaml) and
-                            ~/.config/guessit/options.(json|yml|yaml). Set to
-                            "false" to disable default configuration file loading.
       -t TYPE, --type TYPE  The suggested file type: movie, episode. If undefined,
                             type will be guessed.
       -n, --name-only       Parse files as name only, considering "/" and "\" like
@@ -124,10 +115,25 @@ GuessIt can be used from command line::
                             video_codec, year, ...)
       -a, --advanced        Display advanced information for filename guesses, as
                             json output
+      -s, --first-value     Keep only first found value for each property
+      -l, --enforce-list    Wrap each found value in a list even when property has
+                            a single value
       -j, --json            Display information for filename guesses as json
                             output
       -y, --yaml            Display information for filename guesses as yaml
                             output
+
+    Configuration:
+      -c CONFIG, --config CONFIG
+                            Filepath to the configuration file. Configuration
+                            contains the same options as those command line
+                            options, but option names have "-" characters replaced
+                            with "_". If not defined, guessit tries to read a
+                            configuration default configuration file at
+                            ~/.guessit/options.(json|yml|yaml) and
+                            ~/.config/guessit/options.(json|yml|yaml). Set to
+                            "false" to disable default configuration file loading.
+      --no-embedded-config  Disable default configuration.
 
     Information:
       -p, --properties      Display properties that can be guessed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,11 +67,11 @@ Usage
 GuessIt can be used from command line::
 
     $ guessit
-    usage: guessit [-h] [-c CONFIG] [-t TYPE] [-n] [-Y] [-D]
-                   [-L ALLOWED_LANGUAGES] [-C ALLOWED_COUNTRIES] [-E]
-                   [-T EXPECTED_TITLE] [-G EXPECTED_GROUP] [-f INPUT_FILE] [-v]
-                   [-P SHOW_PROPERTY] [-a] [-j] [-y] [-p] [-V] [--version]
-                   [filename [filename ...]]
+    usage: guessit [-h] [-t TYPE] [-n] [-Y] [-D] [-L ALLOWED_LANGUAGES]
+          [-C ALLOWED_COUNTRIES] [-E] [-T EXPECTED_TITLE] [-G EXPECTED_GROUP]
+          [-f INPUT_FILE] [-v] [-P SHOW_PROPERTY] [-a] [-1] [-l] [-j] [-y]
+          [-c CONFIG] [--no-embedded-config] [-p] [-V] [--version]
+          [filename [filename ...]]
 
     positional arguments:
       filename              Filename or release name to guess
@@ -80,15 +80,6 @@ GuessIt can be used from command line::
       -h, --help            show this help message and exit
 
     Naming:
-      -c CONFIG, --config CONFIG
-                            Filepath to the configuration file. Configuration
-                            contains the same options as those command line
-                            options, but option names have "-" characters replaced
-                            with "_". If not defined, guessit tries to read a
-                            configuration default configuration file at
-                            ~/.guessit/options.(json|yml|yaml) and
-                            ~/.config/guessit/options.(json|yml|yaml). Set to
-                            "false" to disable default configuration file loading.
       -t TYPE, --type TYPE  The suggested file type: movie, episode. If undefined,
                             type will be guessed.
       -n, --name-only       Parse files as name only, considering "/" and "\" like
@@ -122,10 +113,25 @@ GuessIt can be used from command line::
                             video_codec, year, ...)
       -a, --advanced        Display advanced information for filename guesses, as
                             json output
+      -s, --first-value     Keep only first found value for each property
+      -l, --enforce-list    Wrap each found value in a list even when property has
+                            a single value
       -j, --json            Display information for filename guesses as json
                             output
       -y, --yaml            Display information for filename guesses as yaml
                             output
+
+    Configuration:
+      -c CONFIG, --config CONFIG
+                            Filepath to the configuration file. Configuration
+                            contains the same options as those command line
+                            options, but option names have "-" characters replaced
+                            with "_". If not defined, guessit tries to read a
+                            configuration default configuration file at
+                            ~/.guessit/options.(json|yml|yaml) and
+                            ~/.config/guessit/options.(json|yml|yaml). Set to
+                            "false" to disable default configuration file loading.
+      --no-embedded-config  Disable default configuration.
 
     Information:
       -p, --properties      Display properties that can be guessed.

--- a/guessit/__main__.py
+++ b/guessit/__main__.py
@@ -33,8 +33,6 @@ def guess_filename(filename, options):
     if not options.get('yaml') and not options.get('json') and not options.get('show_property'):
         print('For:', filename)
 
-    options['implicit'] = True  # Force implicit option in CLI
-
     guess = api.guessit(filename, options)
 
     if options.get('show_property'):

--- a/guessit/api.py
+++ b/guessit/api.py
@@ -126,7 +126,8 @@ class GuessItApi(object):
                 for match in matches:
                     if isinstance(match.value, six.text_type):
                         match.value = match.value.encode("ascii")
-            return matches.to_dict(options.get('advanced', False), options.get('implicit', False))
+            return matches.to_dict(options.get('advanced', False), options.get('single_value', False),
+                                   options.get('enforce_list', False))
         except:
             raise GuessitException(string, options)
 

--- a/guessit/options.py
+++ b/guessit/options.py
@@ -54,6 +54,10 @@ def build_argument_parser():
                              help='Display the value of a single property (title, series, video_codec, year, ...)')
     output_opts.add_argument('-a', '--advanced', dest='advanced', action='store_true', default=None,
                              help='Display advanced information for filename guesses, as json output')
+    output_opts.add_argument('-s', '--single-value', dest='single_value', action='store_true', default=None,
+                             help='Keep only first found value for each property')
+    output_opts.add_argument('-l', '--enforce-list', dest='enforce_list', action='store_true', default=None,
+                             help='Wrap each found value in a list even when property has a single value')
     output_opts.add_argument('-j', '--json', dest='json', action='store_true', default=None,
                              help='Display information for filename guesses as json output')
     output_opts.add_argument('-y', '--yaml', dest='yaml', action='store_true', default=None,

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -98,7 +98,7 @@ def episodes():
         episode/season separated by a weak discrete separator should be consecutive, unless a strong discrete separator
         or a range separator is present in the chain (1.3&5 is valid, but 1.3-5 is not valid and 1.3.5 is not valid)
         """
-        values = match.children.to_dict(implicit=True)
+        values = match.children.to_dict()
         if 'season' in values and is_iterable(values['season']):
             # Season numbers must be in natural order to be validated.
             if not list(sorted(values['season'])) == values['season']:

--- a/guessit/test/test_yml.py
+++ b/guessit/test/test_yml.py
@@ -207,8 +207,6 @@ class TestYml(object):
             options = {}
         if not isinstance(options, dict):
             options = parse_options(options)
-        if 'implicit' not in options:
-            options['implicit'] = True
         options['config'] = False
         options = load_config(options)
         try:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 with io.open(os.path.join(here, 'HISTORY.rst'), encoding='utf-8') as f:
     history = f.read()
 
-install_requires = ['rebulk>=0.8.2', 'babelfish>=0.5.5', 'python-dateutil']
+install_requires = ['rebulk>=0.9.0', 'babelfish>=0.5.5', 'python-dateutil']
 if sys.version_info < (2, 7):
     install_requires.extend(['argparse', 'ordereddict'])
 setup_requires = ['pytest-runner']


### PR DESCRIPTION
This adds `--enforce-list` and `--single-value` options to CLI (`enforce_list` and `single_value` to API).

Close #274
Close #453