### PR TITLE
'other' is detected with no neighbors

### DIFF
--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -133,6 +133,7 @@ class ValidateHasNeighbor(Rule):
     Validate tag has-neighbor
     """
     consequence = RemoveMatch
+    priority = 64
 
     def when(self, matches, context):
         ret = []
@@ -158,6 +159,7 @@ class ValidateHasNeighborBefore(Rule):
     Validate tag has-neighbor-before that previous match exists.
     """
     consequence = RemoveMatch
+    priority = 64
 
     def when(self, matches, context):
         ret = []
@@ -177,6 +179,7 @@ class ValidateHasNeighborAfter(Rule):
     Validate tag has-neighbor-after that next match exists.
     """
     consequence = RemoveMatch
+    priority = 64
 
     def when(self, matches, context):
         ret = []

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -3895,7 +3895,6 @@
   season: 7
   episode: 22
   episode_title: 2000 Light Years from Home
-  other: Classic
   container: mkv
   mimetype: video/x-matroska
   type: episode
@@ -3962,4 +3961,16 @@
   episode: 9
   subtitle_language: fr
   other: FullHD
+  type: episode
+
+? Whose Line is it anyway/Season 01/Whose.Line.is.it.Anyway.US.S13E01.720p.WEB.x264-TBS.mkv
+: title: Whose Line is it Anyway
+  season: 13
+  episode: 1
+  country: US
+  screen_size: 720p
+  format: WEB-DL
+  video_codec: h264
+  release_group: TBS
+  container: mkv
   type: episode


### PR DESCRIPTION
Fix for #460 