### PR TITLE
Add aspect_ratio and validate screen_sizes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -92,6 +92,8 @@ History
 - Added `Extended Surround` as new `audio_profile` possible value.
 - Added `EX` as new `audio_profile` possible value
 - Added `Opus` as new `audio_codec` possible value
+- Added `aspect_ratio` as new property. Also used to validate if a screen_size is a standard resolution.
+
 
 2.1.4 (2017-06-01)
 ------------------

--- a/docs/properties.rst
+++ b/docs/properties.rst
@@ -148,6 +148,11 @@ Video properties
     ``900p``, ``1080i``, ``1080p``, ``2160p``, ``4320p``
 
 
+- **aspect_ratio**
+
+  Aspect ratio of video. Calculated using width and height from ``screen_size``
+
+
 - **video_codec**
 
   Codec used for video.

--- a/guessit/test/rules/screen_size.yml
+++ b/guessit/test/rules/screen_size.yml
@@ -4,10 +4,23 @@
 ? +360px
 ? "+360"
 ? +500x360
+? -250x360
 : screen_size: 360p
+
+? +640x360
+? -640x360i
+? -684x360i
+: screen_size: 360p
+  aspect_ratio: 1.778
 
 ? +360i
 : screen_size: 360i
+
+? +480x360i
+? -480x360p
+? -450x360
+: screen_size: 360i
+  aspect_ratio: 1.333
 
 ? +368p
 ? +368px
@@ -16,22 +29,83 @@
 ? +500x368
 : screen_size: 368p
 
+? -490x368
+? -700x368
+: screen_size: 368p
+
+? +492x368p
+: screen_size:
+  aspect_ratio: 1.337
+
+? +654x368
+: screen_size: 368p
+  aspect_ratio: 1.777
+
+? +698x368
+: screen_size: 368p
+  aspect_ratio: 1.897
+
+? -368i
+? -368
+: screen_size: 368i
+
 ? +480p
 ? +480px
 ? -480i
 ? "+480"
-? +500x480
+? -500x480
+? -638x480
+? -920x480
 : screen_size: 480p
 
+? +640x480
+: screen_size: 480p
+  aspect_ratio: 1.333
+
+? +852x480
+: screen_size: 480p
+  aspect_ratio: 1.775
+
+? +910x480
+: screen_size: 480p
+  aspect_ratio: 1.896
+
+? +500x480
+? +500 x 480
+? +500 * 480
+? +500x480p
+? +500X480i
+: screen_size: 500x480
+  aspect_ratio: 1.042
+
 ? +480i
+? +852x480i
 : screen_size: 480i
 
 ? +576p
 ? +576px
 ? -576i
 ? "+576"
-? +500x576
+? -500x576
+? -766x576
+? -1094x576
 : screen_size: 576p
+
+? +768x576
+: screen_size: 576p
+  aspect_ratio: 1.333
+
+? +1024x576
+: screen_size: 576p
+  aspect_ratio: 1.778
+
+? +1092x576
+: screen_size: 576p
+  aspect_ratio: 1.896
+
+? +500x576
+: screen_size: 500x576
+  aspect_ratio: 0.868
 
 ? +576i
 : screen_size: 576i
@@ -42,15 +116,53 @@
 ? 720hd
 ? 720pHD
 ? "+720"
-? +500x720
+? -500x720
+? -950x720
+? -1368x720
 : screen_size: 720p
+
+? +960x720
+: screen_size: 720p
+  aspect_ratio: 1.333
+
+? +1280x720
+: screen_size: 720p
+  aspect_ratio: 1.778
+
+? +1366x720
+: screen_size: 720p
+  aspect_ratio: 1.897
+
+? +500x720
+: screen_size: 500x720
+  aspect_ratio: 0.694
 
 ? +900p
 ? +900px
 ? -900i
 ? "+900"
-? +500x900
+? -500x900
+? -1198x900
+? -1710x900
 : screen_size: 900p
+
+? +1200x900
+: screen_size: 900p
+  aspect_ratio: 1.333
+
+? +1600x900
+: screen_size: 900p
+  aspect_ratio: 1.778
+
+? +1708x900
+: screen_size: 900p
+  aspect_ratio: 1.898
+
+? +500x900
+? +500x900p
+? +500x900i
+: screen_size: 500x900
+  aspect_ratio: 0.556
 
 ? +900i
 : screen_size: 900i
@@ -61,27 +173,85 @@
 ? +1080pHD
 ? -1080i
 ? "+1080"
-? +500x1080
+? -500x1080
+? -1438x1080
+? -2050x1080
 : screen_size: 1080p
+
+? +1440x1080
+: screen_size: 1080p
+  aspect_ratio: 1.333
+
+? +1920x1080
+: screen_size: 1080p
+  aspect_ratio: 1.778
+
+? +2048x1080
+: screen_size: 1080p
+  aspect_ratio: 1.896
 
 ? +1080i
 ? -1080p
 : screen_size: 1080i
+
+? +500x1080
+: screen_size: 500x1080
+  aspect_ratio: 0.463
 
 ? +2160p
 ? +2160px
 ? -2160i
 ? "+2160"
 ? +4096x2160
+? +4k
+? -2878x2160
+? -4100x2160
 : screen_size: 2160p
+
+? +2880x2160
+: screen_size: 2160p
+  aspect_ratio: 1.333
+
+? +3840x2160
+: screen_size: 2160p
+  aspect_ratio: 1.778
+
+? +4098x2160
+: screen_size: 2160p
+  aspect_ratio: 1.897
+
+? +500x2160
+: screen_size: 500x2160
+  aspect_ratio: 0.231
 
 ? +4320p
 ? +4320px
 ? -4320i
 ? "+4320"
-? +7680x4320
+? -5758x2160
+? -8198x2160
 : screen_size: 4320p
 
+? +5760x4320
+: screen_size: 4320p
+  aspect_ratio: 1.333
+
+? +7680x4320
+: screen_size: 4320p
+  aspect_ratio: 1.778
+
+? +8196x4320
+: screen_size: 4320p
+  aspect_ratio: 1.897
+
+? +500x4320
+: screen_size: 500x4320
+  aspect_ratio: 0.116
+
 ? Test.File.720hd.bluray
+? Test.File.720p24
+? Test.File.720p30
 ? Test.File.720p50
+? Test.File.720p60
+? Test.File.720p120
 : screen_size: 720p


### PR DESCRIPTION
Fix for #276 

- Added aspect_ratio property
- Validate screen_sizes against aspect_ratio: standard resolutions are represented by the convention 720p, 1080p, etc. Irregular screen sizes are represented by widthxheight. Standard resolutions should have aspect_ratio between 1.333 (4/3) and 1.897 (256:135)
- Also consider 24fps, 30fps and 120 fps in the detection pattern. E.g.: 720p24, 1080p30, 720p120
