### PR TITLE
File and folder name: fine tuning marker comparator

### DIFF
--- a/guessit/rules/common/comparators.py
+++ b/guessit/rules/common/comparators.py
@@ -13,9 +13,12 @@ def marker_comparator_predicate(match):
     """
     Match predicate used in comparator
     """
-    return not match.private and \
-           match.name not in ['proper_count', 'title', 'episode_title', 'alternative_title'] and \
-           not (match.name == 'container' and 'extension' in match.tags)
+    return (
+        not match.private
+        and match.name not in ('proper_count', 'title')
+        and not (match.name == 'container' and 'extension' in match.tags)
+        and not (match.name == 'other' and match.value == 'Rip')
+    )
 
 
 def marker_weight(matches, marker, predicate):
@@ -50,9 +53,8 @@ def marker_comparator(matches, markers, predicate):
         matches_count = marker_weight(matches, marker2, predicate) - marker_weight(matches, marker1, predicate)
         if matches_count:
             return matches_count
-        len_diff = len(marker2) - len(marker1)
-        if len_diff:
-            return len_diff
+
+        # give preference to rightmost path
         return markers.index(marker2) - markers.index(marker1)
 
     return comparator

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4091,4 +4091,3 @@
   release_group: VLAD
   container: mkv
   type: episode
-

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2185,7 +2185,7 @@
   episode: 1
   source: HDTV
   mimetype: video/x-matroska
-  release_group: DIMENSION[rarbg]
+  release_group: DIMENSION
   screen_size: 1080p
   season: 10
   title: The B B T
@@ -4065,3 +4065,30 @@
   release_group: VLAD
   container: mkv
   type: episode
+
+? "/folder/Marvels.Agent.Carter.S02E05.The.Atomic.Job.1080p.WEB-DL.DD5.1.H264-Coo7[rartv]/Marvel's.Agent.Carter.S02E05.The.Atomic.Job.1080p.WEB-DL.DD5.1.H.264-Coo7.mkv"
+: title: Marvel's Agent Carter
+  season: 2
+  episode: 5
+  episode_title: The Atomic Job
+  screen_size: 1080p
+  source: Web
+  audio_codec: Dolby Digital
+  audio_channels: '5.1'
+  video_codec: H.264
+  release_group: Coo7
+  type: episode
+
+? Fear.the.Walking.Dead.S03E07.1080p.AMZN.WEBRip.DD5.1.x264-VLAD[rarbg]/Fear.the.Walking.Dead.S03E07.1080p.AMZN.WEB-DL.DD+5.1.H.264-VLAD.mkv
+: title: Fear the Walking Dead
+  season: 3
+  episode: 7
+  screen_size: 1080p
+  source: Web
+  audio_codec: Dolby Digital Plus
+  audio_channels: '5.1'
+  video_codec: H.264
+  release_group: VLAD
+  container: mkv
+  type: episode
+

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1426,3 +1426,13 @@
   release_group: Hn1Dr2
   container: mkv
   type: movie
+
+? How.To.Be.Single.2016.1080p.BluRay.x264-BLOW/blow-how.to.be.single.2016.1080p.bluray.x264.mkv
+: title: How To Be Single
+  year: 2016
+  screen_size: 1080p
+  source: Blu-ray
+  video_codec: H.264
+  release_group: BLOW
+  container: mkv
+  type: movie


### PR DESCRIPTION
Release names with conflicting information should prefer the information from the rightmost filepart:

Example:
`Fear.the.Walking.Dead.S03E07.1080p.AMZN.WEBRip.DD5.1.x264-VLAD[rarbg]/Fear.the.Walking.Dead.S03E07.1080p.AMZN.WEB-DL.DD+5.1.H.264-VLAD.mkv`

Folder: `WEBRip` and `DD`
File: `WEB-DL` and `DD+`

The marker comparator doesn't need to fallback to marker length. The filepart position index has higher value than the filepart length. Existing test scenarios are there to prove that :-)

This also fixes #275 

