### PR TITLE
Attemp to fix failing pypy env after travis image upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - pypy
+  - pypy-5.4.1
 install:
   - pip install pip --upgrade
   - pip install -e .[dev,test]


### PR DESCRIPTION
Travis updated their ubuntu image and it's not possible to use pypy package without specifying the version:
https://github.com/travis-ci/travis-ci/issues/6865