### PR TITLE
Fix maximum recursion depth exceeded

### DIFF
--- a/guessit/api.py
+++ b/guessit/api.py
@@ -3,6 +3,7 @@
 """
 API functions that can be used by external software
 """
+
 try:
     from collections import OrderedDict
 except ImportError:  # pragma: no-cover
@@ -89,7 +90,7 @@ class GuessItApi(object):
             return value.decode('ascii')
         return value
 
-    def guessit(self, string, options=None):
+    def guessit(self, string, options=None):  # pylint: disable=too-many-branches
         """
         Retrieves all matches from string as a dict
         :param string: the filename or release name
@@ -111,12 +112,18 @@ class GuessItApi(object):
                 fixed_options[key] = value
             options = fixed_options
 
-            if six.PY2 and isinstance(string, six.text_type):
-                string = string.encode("utf-8")
-                result_decode = True
-            if six.PY3 and isinstance(string, six.binary_type):
-                string = string.decode('ascii')
-                result_encode = True
+            if six.PY2:
+                if isinstance(string, six.text_type):
+                    string = string.encode("utf-8")
+                    result_decode = True
+                elif isinstance(string, six.binary_type):
+                    string = six.binary_type(string)
+            if six.PY3:
+                if isinstance(string, six.binary_type):
+                    string = string.decode('ascii')
+                    result_encode = True
+                elif isinstance(string, six.text_type):
+                    string = six.text_type(string)
             matches = self.rebulk.matches(string, options)
             if result_decode:
                 for match in matches:

--- a/guessit/test/test_api_unicode_literals.py
+++ b/guessit/test/test_api_unicode_literals.py
@@ -53,6 +53,14 @@ if six.PY2:
 """
 
 
+def test_ensure_standard_string_class():
+    class CustomStr(str):
+        pass
+
+    ret = guessit(CustomStr('1080p'), options={'advanced': True})
+    assert ret and 'screen_size' in ret and not isinstance(ret['screen_size'].input_string, CustomStr)
+
+
 def test_properties():
     props = properties()
     assert 'video_codec' in props.keys()


### PR DESCRIPTION
Fixes #247 

On python 3, beautifulsoup4 uses NavigableString which doesn't work with deep clone.
This fix ensures that only standard python string classes are passed as input to rebulk.