### PR TITLE
Add support for path-like objects

### DIFF
--- a/guessit/api.py
+++ b/guessit/api.py
@@ -101,6 +101,12 @@ class GuessItApi(object):
         :rtype:
         """
         try:
+            # Handle path-like object
+            string = string.__fspath__()
+        except AttributeError():
+            pass
+        
+        try:
             options = parse_options(options, True)
             result_decode = False
             result_encode = False

--- a/guessit/api.py
+++ b/guessit/api.py
@@ -103,9 +103,9 @@ class GuessItApi(object):
         try:
             # Handle path-like object
             string = string.__fspath__()
-        except AttributeError():
+        except AttributeError:
             pass
-        
+
         try:
             options = parse_options(options, True)
             result_decode = False

--- a/guessit/test/test_api.py
+++ b/guessit/test/test_api.py
@@ -26,20 +26,22 @@ def test_forced_binary():
     ret = guessit(b'Fear.and.Loathing.in.Las.Vegas.FRENCH.ENGLISH.720p.HDDVD.DTS.x264-ESiR.mkv')
     assert ret and 'title' in ret and isinstance(ret['title'], six.binary_type)
 
+
 def test_pathlike_object():
     try:
         from pathlib import Path
     except ImportError:
         class Path(object):
             """A generic path-like object"""
-            def __init__(self, string)
+            def __init__(self, string):
                 self.fspath = string
-        
+
             def __fspath__(self):
                 return self.fspath
     path = Path('Fear.and.Loathing.in.Las.Vegas.FRENCH.ENGLISH.720p.HDDVD.DTS.x264-ESiR.mkv')
     ret = guessit(path)
     assert ret and 'title' in ret
+
 
 def test_unicode_japanese():
     ret = guessit('[阿维达].Avida.2006.FRENCH.DVDRiP.XViD-PROD.avi')

--- a/guessit/test/test_api.py
+++ b/guessit/test/test_api.py
@@ -26,6 +26,20 @@ def test_forced_binary():
     ret = guessit(b'Fear.and.Loathing.in.Las.Vegas.FRENCH.ENGLISH.720p.HDDVD.DTS.x264-ESiR.mkv')
     assert ret and 'title' in ret and isinstance(ret['title'], six.binary_type)
 
+def test_pathlike_object():
+    try:
+        from pathlib import Path
+    except ImportError:
+        class Path(object):
+            """A generic path-like object"""
+            def __init__(self, string)
+                self.fspath = string
+        
+            def __fspath__(self):
+                return self.fspath
+    path = Path('Fear.and.Loathing.in.Las.Vegas.FRENCH.ENGLISH.720p.HDDVD.DTS.x264-ESiR.mkv')
+    ret = guessit(path)
+    assert ret and 'title' in ret
 
 def test_unicode_japanese():
     ret = guessit('[阿维达].Avida.2006.FRENCH.DVDRiP.XViD-PROD.avi')


### PR DESCRIPTION
This allows support for path-like objects such as `pathlib.Path` added in Python 3.4.

Closes #542