### PR TITLE
Add DCU to streaming services

### DIFF
--- a/guessit/rules/properties/streaming_service.py
+++ b/guessit/rules/properties/streaming_service.py
@@ -62,6 +62,7 @@ def streaming_service(config):  # pylint: disable=too-many-statements,unused-arg
     rebulk.string('CUR', value='CuriosityStream')
     rebulk.string('CWS', value='CWSeed')
     rebulk.string('DSKI', value='Daisuki')
+    rebulk.string('DCU', value='DC Universe')
     rebulk.string('DHF', value='Deadhouse Films')
     rebulk.string('DDY', value='Digiturk Diledigin Yerde')
     rebulk.string('DISC', 'Discovery', value='Discovery')

--- a/guessit/test/streaming_services.yaml
+++ b/guessit/test/streaming_services.yaml
@@ -1932,3 +1932,18 @@
   title: GTTV
   type: episode
   video_codec: H.264
+
+? Titans.2018.S01E01.Titans.720p.DCU.WEB-DL.AAC2.0.H264-NTb
+: title: Titans,
+  year: 2018,
+  season: 1,
+  episode: 1,
+  episode_title: Titans,
+  screen_size: 720p,
+  streaming_service: DC Universe,
+  source: Web,
+  audio_codec: AAC,
+  audio_channels: 2.0,
+  video_codec: H.264,
+  release_group: NTb,
+  type: episode


### PR DESCRIPTION
Fixes #584
The result will be:
<pre>
For: Titans.2018.S01E01.Titans.720p.DCU.WEB-DL.AAC2.0.H264-NTb
GuessIt found: {
    "title": "Titans",
    "year": 2018,
    "season": 1,
    "episode": 1,
    "episode_title": "Titans",
    "screen_size": "720p",
    <b>"streaming_service": "DC Universe"</b>,
    "source": "Web",
    "audio_codec": "AAC",
    "audio_channels": "2.0",
    "video_codec": "H.264",
    "release_group": "NTb",
    "type": "episode"
}
</pre>