### PR TITLE
Added NOS4A2 to expected options config

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -1,7 +1,8 @@
 {
   "expected_title": [
     "OSS 117",
-    "This is Us"
+    "This is Us",
+    "NOS4A2"
   ],
   "allowed_countries": [
     "au",


### PR DESCRIPTION
```
Python 2.7.13 (default, Sep 26 2018, 18:42:22)
[GCC 6.3.0 20170516] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import guessit
>>> import json
>>> guessit.__version__
'3.0.4'
>>> print json.dumps(
...     guessit.guessit('NOS4A2.S01E01.The.Shorter.Way.REPACK.720p.AMZN.WEB-DL.DDP5.1.H.264-NTG.mkv'),
...     indent=4
... )

{
    "title": "NOS4A2",
    "season": 1,
    "episode": 1,
    "episode_title": "The Shorter Way",
    "other": "Proper",
    "proper_count": 1,
    "screen_size": "720p",
    "streaming_service": "Amazon Prime",
    "source": "Web",
    "audio_codec": "Dolby Digital Plus",
    "audio_channels": "5.1",
    "video_codec": "H.264",
    "release_group": "NTG",
    "container": "mkv",
    "mimetype": "video/x-matroska",
    "type": "episode"
}
>>>
```

vs without expected title..

```
{
    "title": "NOS4",
    "season": [
        2,
        1
    ],
    "episode": 1,
    "episode_title": "The Shorter Way",
    "other": "Proper",
    "proper_count": 1,
    "screen_size": "720p",
    "streaming_service": "Amazon Prime",
    "source": "Web",
    "audio_codec": "Dolby Digital Plus",
    "audio_channels": "5.1",
    "video_codec": "H.264",
    "release_group": "NTG",
    "container": "mkv",
    "mimetype": "video/x-matroska",
    "type": "episode"
}
```
