### PR TITLE
Add missing `six` dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with io.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 with io.open(os.path.join(here, 'HISTORY.rst'), encoding='utf-8') as f:
     history = f.read()
 
-install_requires = ['rebulk', 'babelfish', 'python-dateutil']
+install_requires = ['rebulk', 'babelfish', 'python-dateutil', 'six']
 
 setup_requires = ['pytest-runner']
 


### PR DESCRIPTION
The code clearly uses `six`, so it should have it listed as a dependency.