### PR TITLE
Fix GuessitException when using Assrt Provider to download subtitles

### DIFF
--- a/guessit/options.py
+++ b/guessit/options.py
@@ -225,7 +225,7 @@ def merge_option_value(option, value, merged):
     if value is not None and option != 'pristine':
         if option in merged.keys() and isinstance(merged[option], list):
             for val in value:
-                if val not in merged[option]:
+                if val not in merged[option] and val is not None:
                     merged[option].append(val)
         elif option in merged.keys() and isinstance(merged[option], dict):
             merged[option] = merge_options(merged[option], value)


### PR DESCRIPTION
GuessitException occur when using Assrt to download subtitles in project [morpheus65535/bazarr](https://github.com/morpheus65535/bazarr)

> Occur Series
> Fleabag Season 2 Episode 3

When Assrt download a new episode and use guessit to parse info,`merge_options` will merge the None value in `options` to 
`config`

### 'allow_countries' in config
<img width="318" alt="image" src="https://user-images.githubusercontent.com/23134797/94265325-e01f8600-ff6a-11ea-8c0e-47c5c530d949.png">

### 'allow_countries' in options
<img width="324" alt="image" src="https://user-images.githubusercontent.com/23134797/94265374-f7f70a00-ff6a-11ea-92f5-bcd15c0fcbe9.png">

### result
```
'allowed_countries': ['au', 'gb', 'us', None]
```

This pull request will fix this issue by adding an None check when merging option value
