### PR TITLE
Add Input filename passthrough for CLI tool

### DIFF
--- a/guessit/__main__.py
+++ b/guessit/__main__.py
@@ -32,6 +32,7 @@ def guess_filename(filename, options):
         print('For:', filename)
 
     guess = api.guessit(filename, options)
+    guess["raw_input"] = filename
 
     if options.get('show_property'):
         print(guess.get(options.get('show_property'), ''))

--- a/guessit/test/test_main.py
+++ b/guessit/test/test_main.py
@@ -3,6 +3,7 @@
 # pylint: disable=no-self-use, pointless-statement, missing-docstring, invalid-name
 
 import os
+import sys
 
 import pytest
 
@@ -10,6 +11,12 @@ from ..__main__ import main
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
+# Prevent output from spamming the console
+@pytest.fixture(scope="function", autouse=True)
+def no_stdout(monkeypatch):
+    with open(os.devnull, "w") as f:
+        monkeypatch.setattr(sys, "stdout", f)
+        yield
 
 def test_main_no_args():
     main([])


### PR DESCRIPTION
Passing the input filename through to the output allows consumers of the `guessit` command output to grab the filename directly in the same way as other properties. This is especially helpful when processing multiple filenames and iterating over the results.

Example:
```bash
guessit --json *.mkv | jq -r '"\(.raw_input):\(.title):\(.season):\(.episode)"' | \
while IFS=':' read -r filename show season episode; do
    echo "Processing $filename --> $show - S${season}E${episode}"
    # actually process the file
done
```

The `raw_input` key was only added when running the CLI tool since code that uses `guessit` as a library won't need this functionality.