### PR TITLE
Add support for "Hybrid" and "iT"

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -490,7 +490,10 @@
       "Hulu": "HULU",
       "Investigation Discovery": "ID",
       "IFC": "IFC",
-      "iTunes": "iTunes",
+      "iTunes": [
+        "iT",
+        "iTunes"
+      ],
       "ITV": "ITV",
       "Knowledge Network": "KNOW",
       "Lifetime": "LIFE",

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -86,7 +86,7 @@ def other(config):  # pylint:disable=unused-argument,too-many-statements
     rebulk.regex('(HD)(?P<another>Rip)', value={'other': 'HD', 'another': 'Rip'},
                  private_parent=True, children=True, validator={'__parent__': seps_surround}, validate_all=True)
 
-    for value in ('Screener', 'Remux', 'PAL', 'SECAM', 'NTSC', 'XXX'):
+    for value in ('Screener', 'Remux', 'Hybrid', 'PAL', 'SECAM', 'NTSC', 'XXX'):
         rebulk.string(value, value=value)
     rebulk.string('3D', value='3D', tags='has-neighbor')
 

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1752,6 +1752,7 @@
   year: 2018
   other:
   - 3D
+  - Hybrid
   - Proper
   - Remux
   proper_count: 1

--- a/guessit/test/rules/other.yml
+++ b/guessit/test/rules/other.yml
@@ -80,6 +80,9 @@
 ? Remux
 : other: Remux
 
+? Hybrid
+: other: Hybrid
+
 ? 3D.2019
 : other: 3D
 


### PR DESCRIPTION
This adds support for the `Hybrid` tag and adds it to `other`.