### PR TITLE
Don't delete pattern for streaming_service

### DIFF
--- a/guessit/rules/properties/streaming_service.py
+++ b/guessit/rules/properties/streaming_service.py
@@ -31,9 +31,8 @@ def streaming_service(config):  # pylint: disable=too-many-statements,unused-arg
         patterns = items if isinstance(items, list) else [items]
         for pattern in patterns:
             if isinstance(pattern, dict):
-                pattern_value = pattern.pop('pattern')
-                kwargs = pattern
-                pattern = pattern_value
+                kwargs = dict(pattern)
+                pattern = kwargs.pop('pattern')
             else:
                 kwargs = {}
             regex = kwargs.pop('regex', False)


### PR DESCRIPTION
This causes the `advanced_config` and `self.advanced_config` to differ without any changes to the default config.
https://github.com/guessit-io/guessit/blob/develop/guessit/api.py#L151-L154

I noticed this because our rebulk rules were being rebuilt without any apparent reason.