### PR TITLE
feat(other): add ONA/OAD support

### DIFF
--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -123,6 +123,8 @@ def other(config):  # pylint:disable=unused-argument,too-many-statements
 
     rebulk.string('VO', 'OV', value='Original Video', tags='has-neighbor')
     rebulk.string('Ova', 'Oav', value='Original Animated Video')
+    rebulk.string('Ona', value='Original Net Animation')
+    rebulk.string('Oad', value='Original Animation DVD')
 
     rebulk.regex('Scr(?:eener)?', value='Screener', validator=None,
                  tags=['other.validate.screener', 'source-prefix', 'source-suffix'])

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4691,3 +4691,27 @@
   container: mp4
   mimetype: video/mp4
   type: episode
+
+? "Seitokai Yakuindomo - 14 OAD [BDRip 1920x1080 x264 FLAC].mkv"
+: title: Seitokai Yakuindomo
+  episode: 14
+  source: Blu-ray
+  other: [Original Animation DVD, Rip]
+  screen_size: 1080p
+  aspect_ratio: 1.778
+  video_codec: H.264
+  audio_codec: FLAC
+  container: mkv
+  mimetype: video/x-matroska
+  type: episode
+
+? "[EveTaku] Kyouso Giga ONA v2 [540p][128BAC43].mkv"
+: release_group: EveTaku
+  title: Kyouso Giga
+  other: Original Net Animation
+  version: 2
+  screen_size: 540p
+  crc32: 128BAC43
+  container: mkv
+  mimetype: video/x-matroska
+  type: episode


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Original_net_animation

https://en.wikipedia.org/wiki/Original_video_animation
> Starting in 2008, the term OAD (original animation DVD) began to refer to DVD releases published bundled with their source-material manga.