### PR TITLE
fix(streaming_service): make SBS ambiguous

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -769,7 +769,7 @@
       "The Roku Channel": "ROKU",
       "RTE One": "RTE",
       "RUUTU": "RUUTU",
-      "SBS (AU)": "SBS",
+      "SBS": "SBS",
       "Science Channel": "SCI",
       "SeeSo": [
         "SESO",

--- a/guessit/test/streaming_services.yaml
+++ b/guessit/test/streaming_services.yaml
@@ -1595,7 +1595,7 @@
   screen_size: 720p
   season: 2
   source: Web
-  streaming_service: SBS (AU)
+  streaming_service: SBS
   title: The Family Law
   type: episode
   video_codec: H.264


### PR DESCRIPTION
SBS is used ambiguously for both:
- Special Broadcasting Service (Australia)
- SBS Broadcasting Group (previously Scandinavian Broadcasting Systems)

White.Wall.S01E01.720p.SBS.WEB-DL.AAC2.0.H.264-GBone.mkv (Scandanavia)
Gourmet.Farmer.S05E01.720p.SBS.WEB-DL.AAC2.0.H.264-SOIL.mkv (AU)