### PR TITLE
Fix screen size remaster

### DIFF
--- a/guessit/rules/properties/edition.py
+++ b/guessit/rules/properties/edition.py
@@ -40,6 +40,8 @@ def edition(config):  # pylint:disable=unused-argument
     rebulk.regex('extended', 'extended-?cut', 'extended-?version',
                  value='Extended', tags=['has-neighbor', 'release-group-prefix'])
     rebulk.regex('alternat(e|ive)(?:-?Cut)?', value='Alternative Cut', tags=['has-neighbor', 'release-group-prefix'])
+    rebulk.regex(r'(?i:4k[ \.]?(remaster(ed|)))', value='4k Remastered', tags=['release-group-prefix'])
+    rebulk.regex(r'(?i:4k[ \.]?restored)', value='4k Restored', tags=['release-group-prefix'])
     for value in ('Remastered', 'Uncensored', 'Uncut', 'Unrated'):
         rebulk.string(value, value=value, tags=['has-neighbor', 'release-group-prefix'])
     rebulk.string('Festival', value='Festival', tags=['has-neighbor-before', 'has-neighbor-after'])

--- a/guessit/rules/properties/screen_size.py
+++ b/guessit/rules/properties/screen_size.py
@@ -45,7 +45,7 @@ def screen_size(config):
     rebulk.regex(res_pattern + progressive_pattern + r'(?P<scan_type>p)' + frame_rate_pattern + '?')
     rebulk.regex(res_pattern + progressive_pattern + r'(?P<scan_type>p)?(?:hd)')
     rebulk.regex(res_pattern + progressive_pattern + r'(?P<scan_type>p)?x?')
-    rebulk.string('4k', value='2160p')
+    rebulk.regex('4k(?![ \.]?(?i:restored|remaster(ed|)))', value='2160p')
     rebulk.regex(r'(?P<width>\d{3,4})-?(?:x|\*)-?(?P<height>\d{3,4})',
                  conflict_solver=lambda match, other: '__default__' if other.name == 'screen_size' else other)
 

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1316,6 +1316,7 @@
 
 ? Heathers.1988.1080p.BluRay.ARROW.4K.RESTORED.Plus.Comm.DTS.x264-MaG
 : title: Heathers
+  edition: [4k Restored]
   year: 1988
   screen_size: 1080p
   release_group: MaG
@@ -1323,6 +1324,7 @@
 
 ? The.Woman.2011.1080p.BluRay.4K.REMASTERED.Remux.AVC.DTS-HD.MA.5.1-PTP.mkv
 : title: The Woman
+  edition: [4k Remastered]
   year: 2011
   screen_size: 1080p
   release_group: PTP

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1314,6 +1314,20 @@
   release_group: ETRG
   type: movie
 
+? Heathers.1988.1080p.BluRay.ARROW.4K.RESTORED.Plus.Comm.DTS.x264-MaG
+: title: Heathers
+  year: 1988
+  screen_size: 1080p
+  release_group: MaG
+  type: movie
+
+? The.Woman.2011.1080p.BluRay.4K.REMASTERED.Remux.AVC.DTS-HD.MA.5.1-PTP.mkv
+: title: The Woman
+  year: 2011
+  screen_size: 1080p
+  release_group: PTP
+  type: movie
+
 ? Delibal 2015 720p Upscale DVDRip x264 DD5.1 AC3
 : title: Delibal
   year: 2015


### PR DESCRIPTION
For "Foo 2000 1080p BluRay 4K REMASTERED", 1080p is misdetected as the alternative title because 4k is interpreted as the resolution. The first commit fixes this.

The second commit also adds "4k Remastered" to the "edition" field.