### PR TITLE
fix(other): detect "Open Matte" with period separator

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -503,7 +503,7 @@
         "Read NFO": {"regex": "Read-?NFO"},
         "Converted": {"string": "CONVERT", "tags": "has-neighbor"},
         "Documentary": {"string": ["DOCU", "DOKU"], "tags": "has-neighbor"},
-        "Open Matte": {"string": ["OM", "Open Matte"], "tags": "has-neighbor"},
+        "Open Matte": {"regex": "(?:OM|Open-?Matte)", "tags": "has-neighbor"},
         "Straight to Video": {"string": "STV", "tags": "has-neighbor"},
         "Original Aspect Ratio": {"string": "OAR", "tags": "has-neighbor"},
         "East Coast Feed": {"regex": "(?:Live-)?(?:Episode-)?East-?(?:Coast-)?Feed"},

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1079,6 +1079,17 @@
   video_codec: H.264
   type: movie
 
+? foo.bar.2015.open.matte.1080p.web-dl.dd+5.1.h.264
+: title: foo bar
+  year: 2015
+  other: Open Matte
+  screen_size: 1080p
+  source: Web
+  audio_codec: Dolby Digital Plus
+  audio_channels: '5.1'
+  video_codec: H.264
+  type: movie
+
 ? Kampen Om Tungtvannet aka The Heavy Water War COMPLETE 720p x265 HEVC-Lund
 : title: Kampen Om Tungtvannet aka The Heavy Water War
   other: Complete


### PR DESCRIPTION
This fixes detection of "Open Matte" when "." is used instead of " " in the release name.