### PR TITLE
fix(packaging): use stdlib importlib.resources in py 3.7+

### DIFF
--- a/guessit/options.py
+++ b/guessit/options.py
@@ -9,7 +9,10 @@ import os
 import shlex
 from argparse import ArgumentParser
 
-from importlib_resources import read_text
+try:
+    from importlib.resources import read_text
+except ImportError:
+    from importlib_resources import read_text
 
 
 def build_argument_parser():

--- a/guessit/rules/properties/website.py
+++ b/guessit/rules/properties/website.py
@@ -3,7 +3,11 @@
 """
 Website property.
 """
-from importlib_resources import open_text  # @UnresolvedImport
+try:
+    from importlib.resources import open_text  # @UnresolvedImport
+except ImportError:
+    from importlib_resources import open_text  # @UnresolvedImport
+
 from rebulk.remodule import re
 
 from rebulk import Rebulk, Rule, RemoveMatch

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 with io.open(os.path.join(here, 'CHANGELOG.md'), encoding='utf-8') as f:
     changelog = f.read()
 
-install_requires = ['rebulk>=3.1.0', 'babelfish', 'python-dateutil', 'importlib-resources']
+install_requires = ['rebulk>=3.1.0', 'babelfish', 'python-dateutil', 'importlib-resources;python_version<"3.7"']
 
 setup_requires = ['pytest-runner']
 


### PR DESCRIPTION
importlib.resources is available as a stdlib module since Python 3.7.
Use that if it's available, and fall back to the external
importlib_resources back for Python < 3.7.