### PR TITLE
fix(audio_codec): Detect "E-AC-3" and "AC-3"

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -55,10 +55,10 @@
       "audio_codec": {
         "MP3": {"string": ["MP3", "LAME"],"regex": ["LAME(?:\\d)+-?(?:\\d)+"]},
         "MP2": "MP2",
-        "Dolby Digital": {"string": ["Dolby", "DolbyDigital"], "regex": ["Dolby-Digital", "DD", "AC3D?"]},
+        "Dolby Digital": {"string": ["Dolby", "DolbyDigital"], "regex": ["Dolby-Digital", "DD", "AC-?3D?"]},
         "Dolby Atmos": {"string": ["Atmos"], "regex": ["Dolby-?Atmos"]},
         "AAC": "AAC",
-        "Dolby Digital Plus": ["EAC3", "DDP", "DD+"],
+        "Dolby Digital Plus": {"string": ["DDP", "DD+"], "regex": ["E-?AC-?3"]},
         "FLAC": "Flac",
         "DTS": "DTS",
         "DTS-HD": {"regex":  ["DTS-?HD", "DTS(?=-?MA)"], "conflict_solver": "lambda match, other: other if other.name == 'audio_codec' else '__default__'"},

--- a/guessit/test/rules/audio_codec.yml
+++ b/guessit/test/rules/audio_codec.yml
@@ -15,11 +15,15 @@
 ? +DD
 ? +Dolby Digital
 ? +AC3
+? +AC-3
 : audio_codec: Dolby Digital
 
 ? +DDP
 ? +DD+
 ? +EAC3
+? +EAC-3
+? +E-AC-3
+? +E-AC3
 : audio_codec: Dolby Digital Plus
 
 ? +DolbyAtmos


### PR DESCRIPTION
This fixes detection of AC3 and EAC3 with dashes (AC-3, E-AC-3, EAC-3, etc):

### Without the fix:

```sh
$ guessit 'Foo 2009 E-AC-3 5.1-ASDF'
For: Foo 2009 E-AC-3 5.1-ASDF
GuessIt found: {
    "title": "Foo",
    "year": 2009,
    "alternative_title": "E-AC-3",
    "audio_channels": "5.1",
    "release_group": "ASDF",
    "type": "movie"
}
```

### With the fix:

```sh
$ guessit 'Foo 2009 E-AC-3 5.1-ASDF'
For: Foo 2009 E-AC-3 5.1-ASDF
GuessIt found: {
    "title": "Foo",
    "year": 2009,
    "audio_codec": "Dolby Digital Plus",
    "audio_channels": "5.1",
    "release_group": "ASDF",
    "type": "movie"
}
```
