### PR TITLE
Properly extract group name from format `Title (MediaInfo Individual) [Group]`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ welcome!
     for issues that should be ideal for people who are not very familiar
     with the codebase yet.
 2.  Fork [the repository][] on Github to start making your changes to
-    the **master** branch (or branch off of it).
+    the **develop** branch (or branch off of it).
 3.  Write a test which shows that the bug was fixed or that the feature
     works as expected.
 4.  Send a pull request and bug the maintainer until it gets merged and

--- a/guessit/rules/properties/release_group.py
+++ b/guessit/rules/properties/release_group.py
@@ -4,6 +4,7 @@
 release_group property
 """
 import copy
+import re
 
 from rebulk import Rebulk, Rule, AppendMatch, RemoveMatch
 from rebulk.match import Match
@@ -50,7 +51,10 @@ def release_group(config):
             if string.lower().endswith(forbidden) and string[-len(forbidden) - 1:-len(forbidden)] in seps:
                 string = string[:len(forbidden)]
                 string = string.strip(groupname_seps)
-        return string.strip()
+
+        # Release groups that credit individual members often use a format like "Title (MediaInfo Individual) [Group]".
+        # This results in a group name of "Individual) [Group]", which should be transformed to "Individual Group".
+        return re.sub(r'(.+)\)\s?\[(.+)\]', r'\1 \2', string.strip())
 
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, 'release_group'))
 

--- a/guessit/test/rules/release_group.yml
+++ b/guessit/test/rules/release_group.yml
@@ -69,3 +69,12 @@
 : title: Show Name
   video_codec: H.264
   release_group: RiPRG
+
+? Archer (2009) S13E01 The Big Con (1080p AMZN Webrip x265 10bit EAC3 5.1 - JBENT)[TAoE]
+: release_group: JBENT TAoE
+
+? Dark Phoenix (2019) (1080p BluRay x265 HEVC 10bit AAC 7.1 Tigole) [QxR]
+: release_group: Tigole QxR
+
+? The Peripheral (2022) Season 1 S01 (1080p AMZN WEB-DL x265 HEVC 10bit DDP5.1 D0ct0rLew) [SEV]
+: release_group: D0ct0rLew SEV


### PR DESCRIPTION
Release groups that credit individual members often use a format like `Title (MediaInfo Individual) [Group]`.
This results in a group name of `Individual) [Group]`, which should be transformed to `Individual Group`.

e.g.
`Archer (2009) S13E01 The Big Con (1080p AMZN Webrip x265 10bit EAC3 5.1 - JBENT)[TAoE]`
`Dark Phoenix (2019) (1080p BluRay x265 HEVC 10bit AAC 7.1 Tigole) [QxR]`
`The Peripheral (2022) Season 1 S01 (1080p AMZN WEB-DL x265 HEVC 10bit DDP5.1 D0ct0rLew) [SEV]`