### PR TITLE
fix(deprecated): importlib.resources.read_text() is deprecated

### DIFF
--- a/guessit/options.py
+++ b/guessit/options.py
@@ -7,12 +7,24 @@ import copy
 import json
 import os
 import shlex
+import sys
 from argparse import ArgumentParser
 
-try:
-    from importlib.resources import read_text
-except ImportError:
-    from importlib_resources import read_text
+# importlib.resources.read_text() is deprecated since Python 3.11.
+# importlib.resources.files() is new in Python 3.9.
+if sys.version_info >= (3, 9, 0):
+    from importlib.resources import files
+
+    def read_text(package, filename):
+        """
+        Should behave like deprecated importlib.resources.read_text()
+        """
+        return files(package).joinpath(filename).read_text()
+else:
+    try:
+        from importlib.resources import read_text
+    except ImportError:
+        from importlib_resources import read_text
 
 
 def build_argument_parser():

--- a/guessit/options.py
+++ b/guessit/options.py
@@ -19,7 +19,7 @@ if sys.version_info >= (3, 9, 0):
         """
         Should behave like deprecated importlib.resources.read_text()
         """
-        return files(package).joinpath(filename).read_text()
+        return files(package).joinpath(filename).read_text()  # pylint:disable=unspecified-encoding
 else:
     try:
         from importlib.resources import read_text


### PR DESCRIPTION
References:

https://docs.python.org/3/library/importlib.resources.html#importlib.resources.read_text
https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files
https://docs.python.org/3/library/importlib.resources.abc.html#importlib.resources.abc.Traversable
