### PR TITLE
chore(lint): Silence pylint

### DIFF
--- a/guessit/rules/match_processors.py
+++ b/guessit/rules/match_processors.py
@@ -18,3 +18,4 @@ def strip(match, chars=seps):
         match.end -= 1
     if not match:
         return False
+    return None


### PR DESCRIPTION
This fixes the following error:

```
************* Module guessit.rules.match_processors
guessit/rules/match_processors.py:7:0: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
```
