### PR TITLE
Enable Filepart2EpisodeTitle rule with absolute episodes

### DIFF
--- a/guessit/rules/properties/episode_title.py
+++ b/guessit/rules/properties/episode_title.py
@@ -6,6 +6,7 @@ Episode title
 from collections import defaultdict
 
 from rebulk import Rebulk, Rule, AppendMatch, RemoveMatch, RenameMatch, POST_PROCESS
+from rebulk.rebulk import Matches
 
 from ..common import seps, title_seps
 from ..common.formatters import cleanup
@@ -272,6 +273,9 @@ class Filepart2EpisodeTitle(Rule):
 
     If BBBB contains season and episode and AAA contains a hole
     then title is to be found in AAAA.
+
+    If BBBB contais the episode and no season is found (absolute numbering)
+    then title is to be found in AAAA.
     """
     consequence = AppendMatch('title')
 
@@ -290,7 +294,7 @@ class Filepart2EpisodeTitle(Rule):
         if episode_number:
             season = (matches.range(directory.start, directory.end, lambda match: match.name == 'season', 0) or
                       matches.range(filename.start, filename.end, lambda match: match.name == 'season', 0))
-            if season:
+            if season or not matches.named("season"):
                 hole = matches.holes(directory.start, directory.end,
                                      ignore=or_(lambda match: 'weak-episode' in match.tags, TitleBaseRule.is_ignored),
                                      formatter=cleanup, seps=title_seps,

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4770,3 +4770,10 @@
   video_codec: H.264
   release_group: NOGRP
   type: episode
+
+? video/zettai karen children/01 - Absolutely Lovely! Their Name Is The Children.mkv
+: title: "zettai karen children"
+  episode: 1
+  episode_title: "Absolutely Lovely! Their Name Is The Children"
+  container: mkv
+  type: episode

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+{pkgs ? import <nixpkgs> {}}: let
+  python = pkgs.python312.withPackages (ps:
+    with ps; [
+    rebulk
+    babelfish
+    python-dateutil
+    pytest
+    pytest-mock
+    pytest-benchmark
+    pytest-cov
+    pylint
+    pyyaml
+    ]);
+in
+  pkgs.mkShell {
+    packages = [
+      python
+    ];
+  }


### PR DESCRIPTION
Animes tend to be in absolute episode numbering, this PR enables naming like:

`Serie name/01 - Episode name.mp4`