### PR TITLE
Ensure `episode_title` is still populated for repacks

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -447,7 +447,7 @@
         "Dual Audio": {"string": ["Dual"], "regex": ["Dual-?Audio"]},
         "Widescreen": {"string": ["ws"], "regex": ["wide-?screen"]},
         "Reencoded": {"regex": ["Re-?Enc(?:oded)?"]},
-        "_repack_with_count": {"regex": ["Repack(?P<proper_count>\\d*)", "Rerip(?P<proper_count>\\d*)"], "value": {"other": "Proper"}, "tags": ["streaming_service.prefix", "streaming_service.suffix"]},
+        "_repack_with_count": {"regex": ["Repack(?P<proper_count>\\d*)", "Rerip(?P<proper_count>\\d*)"], "value": {"other": "Proper"}, "tags": ["streaming_service.prefix", "streaming_service.suffix", "repack"]},
         "Proper": [
           {"string": "Proper", "tags": ["has-neighbor", "streaming_service.prefix", "streaming_service.suffix"]},
           {"regex": ["Real-Proper", "Real-Repack", "Real-Rerip"], "tags": ["streaming_service.prefix", "streaming_service.suffix", "real"]},

--- a/guessit/rules/properties/episode_title.py
+++ b/guessit/rules/properties/episode_title.py
@@ -134,7 +134,7 @@ class EpisodeTitleFromPosition(TitleBaseRule):
 
     def hole_filter(self, hole, matches):
         episode = matches.previous(hole,
-                                   lambda previous: previous.named(*self.previous_names),
+                                   lambda previous: previous.named(*self.previous_names) or previous.tagged('repack'),
                                    0)
 
         crc32 = matches.named('crc32')

--- a/guessit/test/rules/episodes.yml
+++ b/guessit/test/rules/episodes.yml
@@ -341,3 +341,12 @@
   season: 32
   week: 45
   episode: 6478
+
+? Some.Series.S00E01.Some.Episode.Title.1080p.WEBRip.x265.AAC.2.0-SOMEGROUP.mkv
+: title: Some Series
+  episode_title: Some Episode Title
+
+? Some.Series.S00E01.REPACK.Some.Episode.Title.1080p.WEBRip.x265.AAC.2.0-SOMEGROUP.mkv
+: title: Some Series
+  episode_title: Some Episode Title
+  proper_count: 1


### PR DESCRIPTION
Resolves https://github.com/guessit-io/guessit/issues/775

The issue was the `matches.previous(hole)` would contain `[<Proper:(19, 25)+name=other+tags=['streaming_service.prefix', 'streaming_service.suffix']>]` which didn't match the previous names we were looking for.

Adding `other` to the previous names broke other tests so I opted for adding a `repack` tag for this case since it felt more appropriate than using `streaming_service.prefix` or `streaming_service.suffix` for this condition.

From there I just added another case to the lamda to also match it when the hole had the `repack` tag which resolved my case and didn't break any other tests.