### PR TITLE
feat(source): add support for LDRip and Laserdisc

### DIFF
--- a/guessit/rules/properties/source.py
+++ b/guessit/rules/properties/source.py
@@ -75,6 +75,12 @@ def source(config):  # pylint:disable=unused-argument
     rebulk.regex(*build_source_pattern('VIDEO-?TS', 'DVD-?R(?:$|(?!E))',  # 'DVD-?R(?:$|^E)' => DVD-Real ...
                                        'DVD-?9', 'DVD-?5'), value='DVD')
 
+    # LD also means "Line Dubbed", so we only interpret this as Laserdisc with a Rip suffix.
+    rebulk.regex(*build_source_pattern('LD', suffix=rip_suffix),
+                 value={'source': 'LD', 'other': 'Rip'})
+    rebulk.regex(*build_source_pattern('laserdisc', suffix=optional(rip_suffix)),
+                 value={'source': 'LD', 'other': 'Rip'})
+
     rebulk.regex(*build_source_pattern('HD-?TV', suffix=optional(rip_suffix)), conflict_solver=demote_other,
                  value={'source': 'HDTV', 'other': 'Rip'})
     rebulk.regex(*build_source_pattern('TV-?HD', suffix=rip_suffix), conflict_solver=demote_other,

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1630,6 +1630,21 @@
   release_group: MANTESH
   type: movie
 
+? Some.Title.1983.LDRip.x264
+: title: Some Title
+  year: 1983
+  source: LD
+  other: Rip
+  video_codec: H.264
+  type: movie
+
+? Some.Title.1983.Laserdisc.x264
+: title: Some Title
+  year: 1983
+  source: LD
+  video_codec: H.264
+  type: movie
+
 ? Family.Katta.2016.1080p.WEB-DL.H263.DD5.1.ESub-DDR
 : title: Family Katta
   year: 2016


### PR DESCRIPTION
This adds support for "LDRip" and "Laserdisc".

"LD" also means "Line Dubbed", so detection of "LD" (without Rip) is still not possible.
