### PR TITLE
Update babelfish requirement to version v0.6.1 and above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
 with io.open(os.path.join(here, 'CHANGELOG.md'), encoding='utf-8') as f:
     changelog = f.read()
 
-install_requires = ['rebulk>=3.2.0', 'babelfish>=0.6.0', 'python-dateutil', 'importlib-resources;python_version<"3.9"']
+install_requires = ['rebulk>=3.2.0', 'babelfish>=0.6.1', 'python-dateutil', 'importlib-resources;python_version<"3.9"']
 
 dev_require = ['tox', 'mkdocs', 'mkdocs-material', 'pyinstaller', 'wheel', 'python-semantic-release', 'twine']
 


### PR DESCRIPTION
babelfish v0.6.0 is incompatible with setuptools v82.0.0. The reason is that setuptools v82.0.0 removed pkg_resources, while babelfish v0.6.0 depends on it.
