### PR TITLE
ci: re-stamp uv.lock on release and harden commit-message check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,14 +91,15 @@ jobs:
           python-version: "3.14"
 
       - name: Check commit messages
-        # PR: validate the PR commits; push: validate the pushed range
-        # (skipped when pushing a brand-new branch with no "before" ref).
+        # PR: validate the PR commits; push: validate the pushed range. On a
+        # brand-new branch (no "before" ref) fall back to the last commit rather
+        # than skipping, so a uv command always runs (an empty run would make
+        # setup-uv's cache step error with "Cache path does not exist").
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             RANGE="${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
           elif [ "${{ github.event.before }}" = "0000000000000000000000000000000000000000" ]; then
-            echo "New branch push, no previous ref to compare against; skipping."
-            exit 0
+            RANGE="HEAD~1..HEAD"
           else
             RANGE="${{ github.event.before }}..${{ github.event.after }}"
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,13 @@ version_variables = ["guessit/__version__.py:__version__"]
 version_toml = ["pyproject.toml:project.version"]
 commit_message = "chore(release): release v{version}"
 commit_author = "github-actions <actions@github.com>"
-build_command = ""
+# `uv lock` re-stamps the bumped version into uv.lock (which pins guessit's own
+# version); `assets` includes it in the release commit so the lockfile never
+# drifts behind the released version (a stale lock dirties the tree and would
+# break the automated main->develop back-merge). Wheels/sdist/binaries are built
+# in the dedicated CI jobs, so no `uv build` is needed here.
+build_command = "uv lock"
+assets = ["uv.lock"]
 
 # commitizen is used only to lint commit messages (Conventional Commits), both
 # via the local pre-commit commit-msg hook and the CI `cz check`. Versioning and


### PR DESCRIPTION
Deux corrections CI/release (alignées sur rebulk).

## 1. Re-stamp `uv.lock` à la release
`semantic-release version` bumpe la version dans `pyproject.toml` + `guessit/__version__.py` mais laissait `uv.lock` sur l'ancienne version → arbre « dirty » qui casse le back-merge `main → develop`.
- `[tool.semantic_release] build_command = "uv lock"` → ré-estampe la version bumpée dans le lock pendant l'étape `version`
- `assets = ["uv.lock"]` → l'inclut dans le commit de release

(guessit build ses wheels/sdist/binaires dans des jobs dédiés → pas besoin de `uv build` ici, contrairement au `uv lock && uv build` de rebulk.)

## 2. Job `commitizen` robuste sur branche neuve
Sur le 1er push d'une branche neuve (`before` = zéro-SHA), le job skippait la vérif → aucun `uv` lancé → le post-step de cache de `setup-uv` faisait échouer le job (`Cache path does not exist`). Désormais fallback sur `HEAD~1..HEAD` : un `uv` tourne toujours et le commit de tête est quand même validé.

## Validation
`uv lock --check` OK · config semantic-release chargée sans erreur · le job commitizen passe maintenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)