### PR TITLE
fix: year / season-number numeric validation (pre-1920 years, year-as-season)

### DIFF
--- a/guessit/rules/common/date.py
+++ b/guessit/rules/common/date.py
@@ -35,7 +35,7 @@ date_regexps = [
 
 def valid_year(year: int) -> bool:
     """Check if number is a valid year"""
-    return 1920 <= year < 2030
+    return 1900 <= year < 2035
 
 
 def valid_week(week: int) -> bool:

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -147,6 +147,18 @@ def episodes(config: dict[str, Any]) -> Rebulk:
             return True
         return bool(seps_surround(match))
 
+    def season_word_not_year(match: Match) -> bool:
+        """
+        Validate a season-word number, rejecting a 4-digit year (e.g. "Season 2025").
+
+        Only applies to the season WORD chain ("Season N"), not SxxExx, so
+        "S2013E14 -> season 2013" stays unaffected (guessit-js parity, #800).
+        """
+        raw = match.raw or ""
+        if re.match(r"^\d{4}$", raw) and 1900 <= int(raw) <= 2100:
+            return False
+        return validate_roman(match)
+
     season_words = config["season_words"]
     episode_words = config["episode_words"]
     of_words = config["of_words"]
@@ -259,13 +271,13 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         formatter={"season": parse_numeral, "count": parse_numeral},
         validator={
             "__parent__": and_(seps_surround, ordering_validator),
-            "season": validate_roman,
+            "season": season_word_not_year,
             "count": validate_roman,
         },
         disabled=lambda context: context.get("type") == "movie" or is_disabled(context, "season"),
     ).defaults(
         formatter={"season": parse_numeral, "count": parse_numeral},
-        validator={"season": validate_roman, "count": validate_roman},
+        validator={"season": season_word_not_year, "count": validate_roman},
         conflict_solver=season_episode_conflict_solver,
     ).regex(build_or_pattern(season_words, name="seasonMarker") + "@?(?P<season>" + numeral + ")").regex(
         r"" + build_or_pattern(of_words) + "@?(?P<count>" + numeral + ")"

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4770,3 +4770,30 @@
   video_codec: H.264
   release_group: NOGRP
   type: episode
+
+# guessit-js parity — a 4-digit year is not a season-word number (#800/#815);
+# with no real season/episode the title falls back to a movie.
+
+? Show.Name.Season.2025.1080p.WEB-DL.x264-GRP.mkv
+: title: Show Name Season
+  year: 2025
+  -season: 2025
+  screen_size: 1080p
+  source: Web
+  video_codec: H.264
+  release_group: GRP
+  container: mkv
+  type: movie
+
+# SxxExx is unaffected: a 4-digit season number is still parsed there
+
+? Show.Name.S2013E14.1080p.HDTV.x264-GRP.mkv
+: title: Show Name
+  season: 2013
+  episode: 14
+  screen_size: 1080p
+  source: HDTV
+  video_codec: H.264
+  release_group: GRP
+  container: mkv
+  type: episode

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1900,3 +1900,15 @@
   other: Micro HD
   screen_size: 1080p
   type: movie
+
+# guessit-js parity — pre-1920 year accepted (#646/#815)
+
+? The.Immigrant.1917.1080p.BluRay.x264-GRP.mkv
+: title: The Immigrant
+  year: 1917
+  screen_size: 1080p
+  source: Blu-ray
+  video_codec: H.264
+  release_group: GRP
+  container: mkv
+  type: movie

--- a/guessit/test/rules/date.yml
+++ b/guessit/test/rules/date.yml
@@ -7,9 +7,14 @@
 
 ? +31.01.15
 ? +31.01.2015
-? +15.01.31
 ? +2015.01.31
 : date: 2015-01-31
+
+# valid_year upper bound widened to 2035 (#646/#815): for this fully ambiguous
+# 2-digit date both 15 and 31 are plausible years, and 2031 is now valid, so
+# dateutil resolves it day-first (15 Jan 2031).
+? +15.01.31
+: date: 2031-01-15
 
 ? +01.02.03
 : date: 2003-02-01


### PR DESCRIPTION
## What

Backports the guessit-js "year / season-number numeric validation" typology.

Closes #815.

## Changes

- **#646 — `valid_year` bounds** widened from `1920..2030` to `1900..2035` (`date.py`), so pre-1920 films (e.g. `The.Immigrant.1917`) and near-future years parse.
- **#800 — year-as-season guard**: new `season_word_not_year` validator rejects a 4-digit year (1900..2100) on the **season WORD** chain, so `Show.Name.Season.2025` no longer yields `season: 2025`. `SxxExx` is untouched, so `S2013E14 → season 2013` still works.
- **#623** — no spurious `season:0` (falls out of the two changes above); `audio_channels: 1.0` already present, verified.

## One corpus shift (resolved)

`15.01.31` previously parsed as `2015-01-31`; with the year upper bound now ≥2031, this fully ambiguous 2-digit date resolves day-first to `2031-01-15`. The fixture was split out and updated with a comment — both readings are arbitrary for this input, and the change is a direct consequence of the documented bound widening. No other fixture changed.

## Validation

- New fixtures: pre-1920 year (`movies.yml`), season-word-vs-year + `SxxExx` control (`episodes.yml`).
- `uv run ruff check` / `ruff format --check` / `uv run mypy` (strict) ✔
- `uv run pytest` → **2161 passed, 4 skipped**.
