### PR TITLE
fix: CJK & Unicode × episode markers, numeric episode_title as episode (#816)

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -290,7 +290,8 @@
         "s"
       ],
       "season_ep_markers": [
-        "x"
+        "x",
+        "×"
       ],
       "disc_markers": [
         "d"
@@ -300,7 +301,8 @@
         "ex",
         "ep",
         "e",
-        "x"
+        "x",
+        "×"
       ],
       "range_separators": [
         "-",

--- a/guessit/rules/properties/episode_title.py
+++ b/guessit/rules/properties/episode_title.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 from rebulk import POST_PROCESS, AppendMatch, Rebulk, RemoveMatch, RenameMatch, Rule
+from rebulk.remodule import re
 
 from ..common import seps, title_seps
 from ..common.formatters import cleanup
@@ -40,6 +41,7 @@ def episode_title(config: dict[str, Any]) -> Rebulk:
         TitleToEpisodeTitle,
         Filepart3EpisodeTitle,
         Filepart2EpisodeTitle,
+        NumericEpisodeTitleToEpisode,
         RenameEpisodeTitleWhenMovieType,
     )
 
@@ -205,6 +207,36 @@ class AlternativeTitleReplace(Rule):
         when_response.name = "episode_title"
         when_response.tags.append("alternative-replaced")
         matches.append(when_response)
+
+
+class NumericEpisodeTitleToEpisode(Rule):
+    """
+    Convert a numeric episode_title into episode when a season is present but no episode was found.
+
+    Anime such as ``Show S2 - 01`` would otherwise yield ``episode_title: "01"`` (upstream #667).
+    """
+
+    priority = POST_PROCESS
+    consequence = RemoveMatch
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        ret: list[Match] = []
+        for filepart in matches.markers.named("path"):
+            if matches.range(filepart.start, filepart.end, lambda m: m.name == "episode" and not m.private, index=0):
+                continue
+            if not matches.range(filepart.start, filepart.end, lambda m: m.name == "season" and not m.private, index=0):
+                continue
+            for episode_title in matches.range(filepart.start, filepart.end, lambda m: m.name == "episode_title"):
+                if re.match(r"^\d{1,3}$", str(episode_title.value).strip()):
+                    ret.append(episode_title)
+        return ret
+
+    def then(self, matches: Matches, when_response: Any, context: dict[str, Any] | None) -> None:
+        for episode_title in when_response:
+            matches.remove(episode_title)
+            episode_title.name = "episode"
+            episode_title.value = int(str(episode_title.value).strip())
+            matches.append(episode_title)
 
 
 class RenameEpisodeTitleWhenMovieType(Rule):

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -193,8 +193,10 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     # CJK (Japanese) episode/season markers (upstream #671, #763).
     # The glyphs never appear in Latin tokens, so no seps-surround validation is needed.
     rebulk.regex(r"第(?P<episode>\d{1,4})話", tags=["SxxExx"], disabled=is_season_episode_disabled)
-    rebulk.regex(r"(?:シーズン|シリーズ)(?P<season>\d{1,2})", tags=["SxxExx"], disabled=is_season_episode_disabled)
-    rebulk.regex(r"(?P<season>\d+)期", tags=["SxxExx"], disabled=is_season_episode_disabled)
+    rebulk.regex(
+        r"(?:シーズン|シリーズ)(?P<season>\d{1,2})(?!\d)", tags=["SxxExx"], disabled=is_season_episode_disabled
+    )
+    rebulk.regex(r"(?<!\d)(?P<season>\d{1,2})期", tags=["SxxExx"], disabled=is_season_episode_disabled)
 
     # S01E02, 01x02, S01S02S03
     rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -190,6 +190,12 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         )
     )
 
+    # CJK (Japanese) episode/season markers (upstream #671, #763).
+    # The glyphs never appear in Latin tokens, so no seps-surround validation is needed.
+    rebulk.regex(r"第(?P<episode>\d{1,4})話", tags=["SxxExx"], disabled=is_season_episode_disabled)
+    rebulk.regex(r"(?:シーズン|シリーズ)(?P<season>\d{1,2})", tags=["SxxExx"], disabled=is_season_episode_disabled)
+    rebulk.regex(r"(?P<season>\d+)期", tags=["SxxExx"], disabled=is_season_episode_disabled)
+
     # S01E02, 01x02, S01S02S03
     rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
         tags=["SxxExx"],

--- a/guessit/rules/properties/screen_size.py
+++ b/guessit/rules/properties/screen_size.py
@@ -50,7 +50,7 @@ def screen_size(config: dict[str, Any]) -> Rebulk:
     interlaced_pattern = build_or_pattern(interlaced, name="height")
     progressive_pattern = build_or_pattern(progressive, name="height")
 
-    res_pattern = r"(?:(?P<width>\d{3,4})(?:x|\*))?"
+    res_pattern = r"(?:(?P<width>\d{3,4})(?:x|\*|×))?"  # noqa: RUF001  # U+00D7 resolution separator
     rebulk.regex(res_pattern + interlaced_pattern + r"(?P<scan_type>i)" + frame_rate_pattern + "?")
     rebulk.regex(res_pattern + progressive_pattern + r"(?P<scan_type>p)" + frame_rate_pattern + "?")
     rebulk.regex(res_pattern + progressive_pattern + r"(?P<scan_type>p)?(?:hd)")
@@ -61,7 +61,7 @@ def screen_size(config: dict[str, Any]) -> Rebulk:
         conflict_solver=lambda match, other: "__default__" if other.name == "screen_size" else match,
     )
     rebulk.regex(
-        r"(?P<width>\d{3,4})-?(?:x|\*)-?(?P<height>\d{3,4})",
+        r"(?P<width>\d{3,4})-?(?:x|\*|×)-?(?P<height>\d{3,4})",  # noqa: RUF001  # U+00D7 separator
         conflict_solver=lambda match, other: "__default__" if other.name == "screen_size" else other,
     )
 

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4797,3 +4797,46 @@
   release_group: GRP
   container: mkv
   type: episode
+
+# --- #816: CJK (Japanese) season/episode markers, Unicode x, numeric episode_title ---
+
+# CJK episode marker 第N話 (upstream #671)
+? Show 第195話.mkv
+: title: Show
+  episode: 195
+  type: episode
+
+# CJK season/episode markers シーズン / 第 / 話 (upstream #763)
+? アニメ シーズン2 第3話.mkv
+: title: "アニメ"
+  season: 2
+  episode: 3
+  type: episode
+
+# CJK season suffix N期 (upstream #763)
+? Title 2期.mkv
+: title: Title
+  season: 2
+  type: episode
+
+# Unicode x (U+00D7) normalised like x (upstream #790)
+? La casa del dragón 2×7.mkv
+: title: La casa del dragón
+  season: 2
+  episode: 7
+  type: episode
+
+? Show 1×02.mkv
+: title: Show
+  season: 1
+  episode: 2
+  type: episode
+
+# Numeric episode_title with a season but no episode becomes the episode (upstream #667)
+? "[ASW] Show - S2 - 01 [1080p].mkv"
+: title: Show
+  season: 2
+  episode: 1
+  release_group: ASW
+  screen_size: 1080p
+  type: episode

--- a/guessit/test/various.yml
+++ b/guessit/test/various.yml
@@ -1419,3 +1419,8 @@
 ? Some.Release.2020.1080p.x264-GRP.webp
 : container: webp
   release_group: GRP
+# --- #816: Unicode × must be read as a resolution separator, not a season/episode ---
+? Movie.1920×1080.BluRay.mkv
+: title: Movie
+  screen_size: 1080p
+  -season: 1920


### PR DESCRIPTION
## Summary
Parity backport from guessit-js for issue class #816.

- Add Japanese (CJK) season/episode markers `第N話`, `シーズン`/`シリーズ`, `N期` to `episodes.py` (upstream #671, #763).
- Add the Unicode multiplication sign `×` (U+00D7) to `season_ep_markers` and `episode_markers` in `options.json` so `2×7` parses like `2x7` (upstream #790).
- Add `NumericEpisodeTitleToEpisode` post-process rule: a numeric `episode_title` with a season but no episode becomes the `episode` (upstream #667).

## Tests
- New regression fixtures in `episodes.yml` for each case.
- Full suite green (`uv run pytest`): 2177 passed, 4 skipped, no fixture flipped.
- Quality gate green: ruff check, ruff format, mypy --strict.

Closes #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)