### PR TITLE
fix: stop short tokens matching glued inside another word; release_group bracket edges (#814)

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -130,7 +130,7 @@
     },
     "cd": {
       "_cd_of_cd_count": {
-        "regex": "cd-?(?P<cd>\\d+)(?:-?of-?(?P<cd_count>\\d+))?",
+        "regex": "(?<!\\d)(?<![^\\W\\d_])cd-?(?P<cd>\\d+)(?:-?of-?(?P<cd_count>\\d+))?",
         "validator": {
           "cd": "lambda match: 0 < match.value < 100",
           "cd_count": "lambda match: 0 < match.value < 100"

--- a/guessit/rules/properties/release_group.py
+++ b/guessit/rules/properties/release_group.py
@@ -400,8 +400,6 @@ class AnimeReleaseGroup(Rule):
                 inner = matches.range(marker.start, marker.end, lambda m: "weak-language" not in m.tags)
                 if not inner:
                     return True
-                if all(m.name == "other" for m in inner):
-                    return True
                 # A leading bracket whose only content is a subtitle-format container name
                 # ([SSA]/[ASS]) is an anime release group, not a container (upstream #670).
                 return marker.start == filepart.start and all(  # noqa: B023
@@ -432,11 +430,7 @@ class AnimeReleaseGroup(Rule):
                     matches.range(
                         empty_group.start,
                         empty_group.end,
-                        lambda m: (
-                            "weak-language" in m.tags
-                            or m.name == "other"
-                            or (m.name == "container" and "subtitle" in m.tags)
-                        ),
+                        lambda m: "weak-language" in m.tags or (m.name == "container" and "subtitle" in m.tags),
                     )
                 )
 

--- a/guessit/rules/properties/release_group.py
+++ b/guessit/rules/properties/release_group.py
@@ -394,12 +394,26 @@ class AnimeReleaseGroup(Rule):
             return False
 
         for filepart in marker_sorted(matches.markers.named("path"), matches):
+
+            def is_group_empty(marker: Match) -> bool:
+                """An "empty" anime group holds no real title text, only ignorable matches."""
+                inner = matches.range(marker.start, marker.end, lambda m: "weak-language" not in m.tags)
+                if not inner:
+                    return True
+                if all(m.name == "other" for m in inner):
+                    return True
+                # A leading bracket whose only content is a subtitle-format container name
+                # ([SSA]/[ASS]) is an anime release group, not a container (upstream #670).
+                return marker.start == filepart.start and all(  # noqa: B023
+                    m.name == "container" and "subtitle" in m.tags for m in inner
+                )
+
             empty_group = matches.markers.range(
                 filepart.start,
                 filepart.end,
                 lambda marker: (
                     marker.name == "group"
-                    and not matches.range(marker.start, marker.end, lambda m: "weak-language" not in m.tags)
+                    and is_group_empty(marker)
                     and marker.value.strip(seps)
                     and not int_coercable(marker.value.strip(seps))
                 ),
@@ -414,7 +428,17 @@ class AnimeReleaseGroup(Rule):
                 group.tags = ["anime"]
                 group.name = "release_group"
                 to_append.append(group)
-                to_remove.extend(matches.range(empty_group.start, empty_group.end, lambda m: "weak-language" in m.tags))
+                to_remove.extend(
+                    matches.range(
+                        empty_group.start,
+                        empty_group.end,
+                        lambda m: (
+                            "weak-language" in m.tags
+                            or m.name == "other"
+                            or (m.name == "container" and "subtitle" in m.tags)
+                        ),
+                    )
+                )
 
         if to_remove or to_append:
             return to_remove, to_append

--- a/guessit/rules/properties/streaming_service.py
+++ b/guessit/rules/properties/streaming_service.py
@@ -55,7 +55,20 @@ class ValidateStreamingService(Rule):
         :return:
         """
         to_remove: list[Match] = []
+        input_string = matches.input_string or ""
         for service in matches.named("streaming_service"):
+            # A short service code (e.g. CN) glued inside a larger token (CNHD) is a
+            # substring of that token, not a real streaming service (upstream #651).
+            raw = service.raw or ""
+            if len(raw) <= 3:
+                char_after = input_string[service.end : service.end + 1]
+                char_before = input_string[service.start - 1 : service.start] if service.start > 0 else ""
+                if (char_after and re.match(r"[a-z0-9]", char_after, re.IGNORECASE)) or (
+                    char_before and re.match(r"[a-z0-9]", char_before, re.IGNORECASE)
+                ):
+                    to_remove.append(service)
+                    continue
+
             next_match = matches.next(service, lambda match: "streaming_service.suffix" in match.tags, 0)
             previous_match = matches.previous(service, lambda match: "streaming_service.prefix" in match.tags, 0)
             has_other = service.initiator and service.initiator.children.named("other")

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4797,3 +4797,10 @@
   release_group: GRP
   container: mkv
   type: episode
+
+# --- #814 / #670: leading subtitle-format bracket [SSA] is an anime release_group ---
+
+? "[SSA] Uma Musume Pretty Derby - 01.mkv"
+: release_group: SSA
+  title: Uma Musume Pretty Derby
+  episode: 1

--- a/guessit/test/streaming_services.yaml
+++ b/guessit/test/streaming_services.yaml
@@ -2355,3 +2355,10 @@
   title: GTTV
   type: episode
   video_codec: H.264
+
+# --- #814 / #651: a <=3-char service code glued inside a release group is not a service ---
+
+? Show.S01E01.720p.x264-CNHD.mkv
+: title: Show
+  release_group: CNHD
+  -streaming_service: Cartoon Network

--- a/guessit/test/various.yml
+++ b/guessit/test/various.yml
@@ -1419,3 +1419,22 @@
 ? Some.Release.2020.1080p.x264-GRP.webp
 : container: webp
   release_group: GRP
+# --- #814: short "cd" token must not match glued inside a larger word/hash ---
+
+? My File 238ddcd5aff.mkv
+: title: My File 238ddcd5aff
+  -cd: 5
+
+# standalone CD tokens still match
+? Movie CD1.avi
+: title: Movie
+  cd: 1
+
+? Movie cd1of2.avi
+: title: Movie
+  cd: 1
+  cd_count: 2
+
+? (CD3) Movie.avi
+: title: Movie
+  cd: 3

--- a/guessit/test/various.yml
+++ b/guessit/test/various.yml
@@ -1438,3 +1438,12 @@
 ? (CD3) Movie.avi
 : title: Movie
   cd: 3
+
+# a bracket whose content is a recognized "other" tag stays "other" (must not become
+# an anime release_group) — only a leading subtitle-format bracket like [SSA] does
+? Show.2020.[Remux].1080p.mkv
+: title: Show
+  year: 2020
+  other: Remux
+  screen_size: 1080p
+  -release_group: Remux


### PR DESCRIPTION
## Summary
Parity backport from guessit-js for issue class #814.

- **#742** `cd`: leading word-boundary lookbehinds `(?<!\d)(?<![^\W\d_])` so `cd<n>` only matches a standalone token. `238ddcd5aff` no longer yields `cd: 5`; `CD1`, `(CD3)`, `cd1of2` still match.
- **#651** `streaming_service`: drop a ≤3-char service code (e.g. `CN`) when glued to an alphanumeric char — a substring of a larger token like `CNHD`.
- **#670** `release_group`: a leading bracket whose only content is a subtitle-format container name (`[SSA]`/`[ASS]`) is treated as an anime release_group, not a container list.

## Tests
- New regression fixtures in `various.yml`, `streaming_services.yaml`, `episodes.yml`.
- Full suite green (`uv run pytest`): 2177 passed, 4 skipped, no fixture flipped.
- Quality gate green: ruff check, ruff format, mypy --strict.

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)