### PR TITLE
ci: drop pypy-3.10 from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # pypy-3.11 is excluded: a pypy-3.11 interpreter bug segfaults when an
-        # AttributeError subclass with an uninitialized `name` is raised from
-        # __getattr__ (babelfish's LanguageConvertError, hit via str(Language)).
-        # Not a guessit bug; fine on pypy-3.10 and all CPython.
-        # Upstream: https://github.com/pypy/pypy/issues/5514
-        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         regex: [ "0", "1" ]
         exclude:
-          # regex module doesn't play well with pypy and unicode.
-          - python-version: "pypy-3.10"
-            regex: "1"
           # test regex module only with Python 3.11.
           - python-version: "3.10"
             regex: "1"
@@ -44,9 +36,8 @@ jobs:
           enable-cache: true
 
       - name: Install Dependencies
-        # --no-dev: the test matrix runs on PyPy too, where dev-only deps
-        # (python-semantic-release/commitizen -> pydantic-core, a Rust/pyo3
-        # extension) have no wheel and fail to build. Only the test group is needed.
+        # --no-dev: the test run only needs the test group; dev-only tooling
+        # (python-semantic-release/commitizen) is not required here.
         run: uv sync --locked --no-dev --group test ${{ matrix.regex == '1' && '--extra regex' || '' }}
 
       - name: Test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-# pypy-3.11 is intentionally excluded (babelfish segfaults pypy-3.11, see ci.yml
-# and https://github.com/pypy/pypy/issues/5514).
-envlist = py310,py311,py312,py313,py314,pypy3.10
+envlist = py310,py311,py312,py313,py314
 
 [testenv]
 runner = uv-venv-lock-runner


### PR DESCRIPTION
## Why
PyPy is a negligible share of guessit's downloads — the user base is overwhelmingly modern CPython (~73% on 3.12 alone, per pypistats; PyPy reports as a CPython minor so its real share is well under 1%). It also stays a language version behind CPython, which forces carve-outs:
- `pypy-3.11` is excluded (babelfish segfaults it, [pypy#5514](https://github.com/pypy/pypy/issues/5514));
- the `regex` extra is excluded under PyPy (unicode issues).

And the PyPy job is the slowest in the matrix: a test suite is many short cases where PyPy's JIT never warms up, so it's a worst case for PyPy (this does **not** reflect PyPy's real runtime speed on long batch jobs, but it does mean the CI job costs the most wall-time for ~zero coverage value).

## What
- Remove `pypy-3.10` from the `ci.yml` matrix and its `regex` exclusion.
- Remove `pypy3.10` from `tox.ini` envlist.
- Drop the now-obsolete PyPy-specific comments in both files.

No source or test changes; the CPython 3.10–3.14 matrix (with the regex variant on 3.11) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)