### PR TITLE
fix: extend lone-article merge to episode_title (#743)

### DIFF
--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -525,8 +525,9 @@ class CountryAtTitlePosition(Rule):
 
 class ExtendLoneArticleTitle(Rule):
     """
-    A title made of a single article ("The") swallows the following edition/language/
-    country/other/source word (upstream #652, #737): "The" + edition "Collector" -> "The Collector".
+    A title or episode_title made of a single article ("The") swallows the following edition/
+    language/country/other/source word (upstream #652, #737, #743): "The" + edition "Collector"
+    -> "The Collector"; "Chapter.19.The.Convert" -> episode_title "The Convert".
     """
 
     priority = -32
@@ -535,7 +536,7 @@ class ExtendLoneArticleTitle(Rule):
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         input_string = matches.input_string or ""
         ret: list[tuple[Match, Match]] = []
-        for title_match in matches.named("title"):
+        for title_match in (*matches.named("title"), *matches.named("episode_title")):
             if str(title_match.value or "").strip().lower() not in ARTICLES:
                 continue
             filepart = matches.markers.at_match(title_match, lambda m: m.name == "path", 0)

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4919,3 +4919,12 @@
   season: 1
   episode: 1
   -title: Shameless in Us
+
+# --- #743: a lone article episode_title swallows the following "other" word ---
+# "The" + other "Converted" -> episode_title "The Convert" (ExtendLoneArticleTitle)
+? Chapter.19.The.Convert.720p.mkv
+: title: Chapter
+  episode: 19
+  episode_title: The Convert
+  screen_size: 720p
+  -other: Converted


### PR DESCRIPTION
Follow-up to #833 / parity #743. Part 1 of 2 (the #732 fix lands in a separate PR).

## Problem
A single-article `episode_title` (`The`) sitting right before an `other`/`source`/`edition`/`language`/`country` keyword left that keyword as a separate property and truncated the episode title:

```
Chapter.19.The.Convert.720p.mkv
  before: episode_title=The, other=Converted
  after:  episode_title=The Convert
```

## Fix
`ExtendLoneArticleTitle` already handled the equivalent **movie** case (`The.Convert.2024` → title `The Convert`, see `movies.yml:1930`), but it only iterated `title`. It now also iterates `episode_title`, reusing the same gap/brackets/separator guards unchanged. The rule runs at priority `-32`, after `episode_title` is built (priority `0`), so the lone article is already present.

## Tests
- New regression fixture in `episodes.yml` (`Chapter.19.The.Convert.720p.mkv`).
- Existing CAM/CONVERT movie fixtures unchanged (`movies.yml:978`, `:1930`).
- Full suite: `2210 passed, 4 skipped`. `ruff` + `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)