### PR TITLE
fix: reclaim a bare "Cam" after the episode marker as episode_title (#732)

### DIFF
--- a/guessit/rules/properties/episode_title.py
+++ b/guessit/rules/properties/episode_title.py
@@ -36,6 +36,7 @@ def episode_title(config: dict[str, Any]) -> Rebulk:
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, "episode_title"))
     return rebulk.rules(
         RemoveConflictsWithEpisodeTitle(previous_names),
+        ReclaimCameraEpisodeTitle,
         EpisodeTitleFromPosition(previous_names),
         AlternativeTitleReplace(previous_names),
         TitleToEpisodeTitle,
@@ -134,6 +135,53 @@ class TitleToEpisodeTitle(Rule):
             matches.remove(title)
             title.name = "episode_title"
             matches.append(title)
+
+
+class ReclaimCameraEpisodeTitle(Rule):
+    """
+    A bare "Cam" right after an episode/season marker, with no other release metadata in the
+    filepart, is the episode title, not ``source: Camera`` (upstream #732):
+    ``Show.S01E01.Cam.mkv`` -> episode_title "Cam".
+
+    Scoped to the ambiguous bare-CAM source ("Camera"): the spurious source match is removed so
+    the normal episode-title hole-filling reclaims the word. Unambiguous sources (HDTV, WEB, ...)
+    and real CAM releases ("720p CAM x264", "...HDCAM XviD") are left untouched because the source
+    word is then either not at the episode-title slot or surrounded by other release metadata.
+
+    Runs before :class:`EpisodeTitleFromPosition` so the freed hole becomes the episode title.
+    """
+
+    priority = 32
+    consequence = RemoveMatch
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        input_string = matches.input_string or ""
+        to_remove: list[Match] = []
+        for source in matches.named("source"):
+            if source.value != "Camera":
+                continue
+            filepart = matches.markers.at_match(source, lambda m: m.name == "path", 0)
+            if not filepart:
+                continue
+            # Must directly follow an episode/season marker (only separators in between).
+            before = matches.range(filepart.start, source.start, lambda m: not m.private and m.value, -1)
+            if not before or before.name not in ("episode", "season", "episode_count", "season_count"):
+                continue
+            if any(ch not in seps for ch in input_string[before.end : source.start]):
+                continue
+            # Must be the trailing word: nothing meaningful after it but a container.
+            after = matches.range(
+                source.end,
+                filepart.end,
+                lambda m: not m.private and m.value and m.name != "container",
+                0,
+            )
+            if after:
+                continue
+            to_remove.append(source)
+            if source.parent:
+                to_remove.append(source.parent)
+        return to_remove
 
 
 class EpisodeTitleFromPosition(TitleBaseRule):

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4928,3 +4928,21 @@
   episode_title: The Convert
   screen_size: 720p
   -other: Converted
+
+# --- #732: a bare "Cam" right after the episode marker is the episode title ---
+# isolated "Cam" (no other release metadata) is reclaimed from source: Camera
+? Show.S01E01.Cam.mkv
+: title: Show
+  season: 1
+  episode: 1
+  episode_title: Cam
+  -source: Camera
+
+# but "Cam" surrounded by release metadata stays source: Camera (real CAM release)
+? Show.S01E01.Cam.720p.x264.mkv
+: title: Show
+  season: 1
+  episode: 1
+  source: Camera
+  screen_size: 720p
+  video_codec: H.264


### PR DESCRIPTION
Follow-up to #833 / parity #732. Part 2 of 2 (the #743 fix is #834).

## Problem
A bare `Cam` right after an episode marker was parsed as `source: Camera`, leaving no episode title:

```
Show.S01E01.Cam.mkv
  before: source=Camera   (no episode_title)
  after:  episode_title=Cam
```

The bare-`CAM` source pattern (`source.py:53`) is genuinely ambiguous — `Cam` is a common word/name — yet it must stay a `source` in real releases (`720p CAM x264`, `...HDCAM XviD`), so the pattern itself cannot be tightened the way bare `TV` is.

## Fix
New rule `ReclaimCameraEpisodeTitle` (`episode_title.py`, priority `32`, runs before `EpisodeTitleFromPosition`) removes the spurious source **only** when the `Camera` word:
- directly follows an episode/season marker (separators only in between), and
- is the lone trailing token (nothing meaningful after it but a container).

The freed hole is then turned into the episode title by the normal hole-filling. Anything else is left untouched:
- unambiguous sources (HDTV, WEB, DVD, …) — value ≠ `Camera`;
- real CAM releases (`720p CAM x264`, `HDCAM`) — surrounded by other release metadata or not at the episode-title slot.

## Tests
New fixtures in `episodes.yml`:
- `Show.S01E01.Cam.mkv` → `episode_title: Cam`, `-source: Camera`;
- `Show.S01E01.Cam.720p.x264.mkv` → stays `source: Camera` (guard against over-reach).

Existing CAM movie fixtures unchanged (`movies.yml:1215`, `:1225`). Full suite: `2211 passed, 4 skipped`. `ruff` + `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)