### PR TITLE
fix: prefer the leading anime [bracket] over a trailing parenthetical as release_group (#696, #757)

### DIFF
--- a/guessit/rules/properties/release_group.py
+++ b/guessit/rules/properties/release_group.py
@@ -106,6 +106,40 @@ _scene_previous_tags = ("release-group-prefix",)
 _scene_no_previous_tags = ("no-release-group-prefix",)
 
 
+def is_anime_group(matches: Matches, marker: Match, filepart_start: int) -> bool:
+    """An "empty" anime group holds no real title text, only ignorable matches.
+
+    A leading bracket whose only content is a subtitle-format container name
+    ([SSA]/[ASS]) is an anime release group, not a container (upstream #670).
+    """
+    inner = matches.range(marker.start, marker.end, lambda m: "weak-language" not in m.tags)
+    if not inner:
+        return True
+    return marker.start == filepart_start and all(m.name == "container" and "subtitle" in m.tags for m in inner)
+
+
+def leading_anime_group(matches: Matches, filepart: Match) -> Match | None:
+    """Return the filepart's leading ``[bracket]`` group when it is an anime release-group tag.
+
+    These releases carry the group in the first bracket (``[ASW] Title - 01 …``); a trailing
+    ``(English Title)`` parenthetical must not be claimed as the release_group instead (#696/#757).
+    """
+    first_group = matches.markers.range(
+        filepart.start,
+        filepart.end,
+        lambda marker: marker.name == "group" and marker.start == filepart.start,
+        0,
+    )
+    if (
+        first_group
+        and is_anime_group(matches, first_group, filepart.start)
+        and first_group.value.strip(seps)
+        and not int_coercable(first_group.value.strip(seps))
+    ):
+        return first_group
+    return None
+
+
 class DashSeparatedReleaseGroup(Rule):
     """
     Detect dash separated release groups that might appear at the end or at the beginning of a release name.
@@ -351,6 +385,12 @@ class SceneReleaseGroup(Rule):
             )
 
             if last_hole:
+                # Anime releases carry the group in the leading [bracket]; a trailing
+                # (English title) parenthetical must not be claimed as the release_group
+                # instead — leave it for AnimeReleaseGroup to pick the leading bracket (#696/#757).
+                hole_group = matches.markers.at_match(last_hole, lambda marker: marker.name == "group", 0)
+                if hole_group and (hole_group.raw or "").startswith("(") and leading_anime_group(matches, filepart):
+                    continue
 
                 def previous_match_filter(match: Match) -> bool:
                     """
@@ -418,24 +458,12 @@ class AnimeReleaseGroup(Rule):
             return False
 
         for filepart in marker_sorted(matches.markers.named("path"), matches):
-
-            def is_group_empty(marker: Match) -> bool:
-                """An "empty" anime group holds no real title text, only ignorable matches."""
-                inner = matches.range(marker.start, marker.end, lambda m: "weak-language" not in m.tags)
-                if not inner:
-                    return True
-                # A leading bracket whose only content is a subtitle-format container name
-                # ([SSA]/[ASS]) is an anime release group, not a container (upstream #670).
-                return marker.start == filepart.start and all(  # noqa: B023
-                    m.name == "container" and "subtitle" in m.tags for m in inner
-                )
-
             empty_group = matches.markers.range(
                 filepart.start,
                 filepart.end,
                 lambda marker: (
                     marker.name == "group"
-                    and is_group_empty(marker)
+                    and is_anime_group(matches, marker, filepart.start)  # noqa: B023
                     and marker.value.strip(seps)
                     and not int_coercable(marker.value.strip(seps))
                 ),

--- a/guessit/rules/properties/release_group.py
+++ b/guessit/rules/properties/release_group.py
@@ -385,11 +385,17 @@ class SceneReleaseGroup(Rule):
             )
 
             if last_hole:
-                # Anime releases carry the group in the leading [bracket]; a trailing
-                # (English title) parenthetical must not be claimed as the release_group
-                # instead — leave it for AnimeReleaseGroup to pick the leading bracket (#696/#757).
+                # Anime episode releases carry the group in the leading [bracket]; a trailing
+                # (English title) parenthetical must not be claimed as the release_group instead —
+                # leave it for AnimeReleaseGroup to pick the leading bracket (#696/#757). Gate on an
+                # episode/season match so a movie's trailing (group) (e.g. YTS/YIFY) is left untouched.
                 hole_group = matches.markers.at_match(last_hole, lambda marker: marker.name == "group", 0)
-                if hole_group and (hole_group.raw or "").startswith("(") and leading_anime_group(matches, filepart):
+                if (
+                    hole_group
+                    and (hole_group.raw or "").startswith("(")
+                    and matches.range(start, end, predicate=lambda m: m.name in ("episode", "season"))
+                    and leading_anime_group(matches, filepart)
+                ):
                     continue
 
                 def previous_match_filter(match: Match) -> bool:

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4904,6 +4904,27 @@
   screen_size: 1080p
   -language: ko
 
+# --- #696/#757: the leading [bracket] is the anime release group, not a trailing (title) ---
+? "[ASW] Fumetsu no Anata e - S01E03 [1080p HEVC x265 10Bit][AAC] (To Your Eternity)"
+: title: Fumetsu no Anata e
+  season: 1
+  episode: 3
+  release_group: ASW
+
+# the trailing "+" is normalised away by StripSeparators (it is a separator); the
+# group is now correctly identified instead of the trailing (WEB … service) parenthetical
+? "[SubsPlus+] Helck - S01E01 (WEB 1080p HIDIVE)"
+: title: Helck
+  season: 1
+  episode: 1
+  release_group: SubsPlus
+
+? "[SubsPlus+] Spy Classroom - S02E01 (WEB 1080p ADN) (Spy Kyoushitsu)"
+: title: Spy Classroom
+  season: 2
+  episode: 1
+  release_group: SubsPlus
+
 # casing guard: an uppercase US tag is a real country, kept
 ? The.Office.US.1x03.mkv
 : title: The Office

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1967,3 +1967,11 @@
   country: US
   year: 2019
   -title: It Ends With Us
+
+# #696/#757 review: the leading-[bracket]/trailing-(group) anime guard is gated on an
+# episode/season, so a movie keeps its trailing (group) and the [site] tag is not claimed
+? "[YTS.MX] Movie Name (2019) 1080p BluRay (YIFY)"
+: title: Movie Name
+  year: 2019
+  release_group: YIFY
+  -release_group: YTS.MX


### PR DESCRIPTION
## What

Fixes the anime release-group detection for releases whose group sits in the **leading `[bracket]`** but which also carry a trailing `(...)` parenthetical.

- **#696** — `[ASW] Fumetsu no Anata e - S01E03 [1080p HEVC x265 10Bit][AAC] (To Your Eternity)`
  → `release_group: ASW` (was `To Your Eternity`)
- **#757** — `[SubsPlus+] Helck - S01E01 (WEB 1080p HIDIVE)`
  → `release_group: SubsPlus` (was `HIDIVE`)
  and `[SubsPlus+] Spy Classroom - S02E01 (WEB 1080p ADN) (Spy Kyoushitsu)`
  → `release_group: SubsPlus` (was the garbled `ADN) (Spy Kyoushitsu)`)

## Why

`SceneReleaseGroup` claims the *last hole* as the release_group. On these anime releases the last hole is the trailing `(English title)` parenthetical, so the real group in the leading bracket is lost — and `AnimeReleaseGroup` then short-circuits because a release_group already exists.

## How

When the last hole sits inside a `(...)` group **and** the filepart starts with a qualifying anime release-group bracket, `SceneReleaseGroup` defers, letting `AnimeReleaseGroup` claim the leading bracket. The distinction between a trailing `(...)` parenthetical and a real trailing scene group (`-GRP`, `[…Chaps]`, `[…Ind]`) keeps existing scene detection intact.

The "empty anime group" test is factored out into shared `is_anime_group()` / `leading_anime_group()` helpers (reused by `AnimeReleaseGroup`).

Note: the trailing `+` of `SubsPlus+` is normalised away by `StripSeparators` (it is a global separator) — consistent with how guessit trims all matches; the group is now correctly *identified*, which was the bug.

## Tests

- New fixtures in `guessit/test/episodes.yml` for the three cases (test-first commit).
- Full suite green: **2214 passed, 4 skipped**, no regressions.

## Out of scope

#747 (leading single-digit episode `5. Title`) is **not** included — it is entangled with the weak-episode/`RemoveDetachedEpisodeNumber` guards (a naive fix regresses 18 corpus cases and doesn't even resolve it). Documented as a scoped follow-up on the issue.
