### PR TITLE
fix: episode_title ending in a lone article absorbs the following word (#743)

### DIFF
--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -525,9 +525,10 @@ class CountryAtTitlePosition(Rule):
 
 class ExtendLoneArticleTitle(Rule):
     """
-    A title or episode_title made of a single article ("The") swallows the following edition/
+    A title or episode_title ending with a lone article ("The") swallows the following edition/
     language/country/other/source word (upstream #652, #737, #743): "The" + edition "Collector"
-    -> "The Collector"; "Chapter.19.The.Convert" -> episode_title "The Convert".
+    -> "The Collector"; "Chapter.19.The.Convert" -> episode_title "The Convert"; and the article
+    may close a longer title -> "Chapter 19 The" + other "Convert" -> "Chapter 19 The Convert".
     """
 
     priority = -32
@@ -537,7 +538,8 @@ class ExtendLoneArticleTitle(Rule):
         input_string = matches.input_string or ""
         ret: list[tuple[Match, Match]] = []
         for title_match in (*matches.named("title"), *matches.named("episode_title")):
-            if str(title_match.value or "").strip().lower() not in ARTICLES:
+            title_words = str(title_match.value or "").strip().split()
+            if not title_words or title_words[-1].lower() not in ARTICLES:
                 continue
             filepart = matches.markers.at_match(title_match, lambda m: m.name == "path", 0)
             if not filepart:

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4950,6 +4950,14 @@
   screen_size: 720p
   -other: Converted
 
+# the article may also close a longer episode_title: "Chapter 19 The" + "Convert"
+? The.Mandalorian.S03E03.Chapter.19.The.Convert.2160p.WEB-DL.DDP5.1.HEVC-Group
+: title: The Mandalorian
+  season: 3
+  episode: 3
+  episode_title: Chapter 19 The Convert
+  -other: Converted
+
 # --- #732: a bare "Cam" right after the episode marker is the episode title ---
 # isolated "Cam" (no other release metadata) is reclaimed from source: Camera
 ? Show.S01E01.Cam.mkv


### PR DESCRIPTION
## What

Cluster C3 (a real title word eaten by a `source`/`other` marker). Fixes **#743**: an `episode_title` that **ends** with a lone article now absorbs the following misparsed `other` word.

`The.Mandalorian.S03E03.Chapter.19.The.Convert.2160p…` → `episode_title: "Chapter 19 The Convert"` (was `"Chapter 19 The"` + `other: Converted`).

## Why

`ExtendLoneArticleTitle` only fired when the *entire* title/episode_title was a single article (`"The"`). A genuine episode_title can end with an article (`"Chapter 19 The"`), so the trailing `Convert→Converted` was still split off.

## How

Match on the **last word** of the title being a lone article instead of the whole value. The existing `then` already extends the title's end across the following word, yielding `"Chapter 19 The Convert"`. The single-article cases (#652 `The Collector`, #737 `The English`, and the #743 minimal case) are unchanged.

## Tests

- Fixture in `guessit/test/episodes.yml` (the full Mandalorian case).
- Full suite green: **2216 passed, 4 skipped**, no regressions.

## Deferred / out of scope (same cluster — documented on the issues)

- **#732** (non-minimal `…S01E01.Cam.1080p.WEB-DL…`) — **by design, not a bug**: the maintainer's fix (`bc33ee8`) deliberately keeps a `Cam` surrounded by release metadata as `source: Camera` (committed test `Show.S01E01.Cam.720p.x264.mkv → source: Camera`); only a *bare* trailing `Cam` becomes `episode_title`. The non-minimal request contradicts that decision.
- **#746** (`Something.Real.1080p` → `other: Proper`) and **#775** (`…S00E01.REPACK.<title>…` drops the episode_title) — both need to distinguish a *legitimate* `REAL`/`REPACK` proper marker (common right after the episode marker) from a same-spelled title word. High regression risk on real proper detection; deferred for dedicated work.
