### PR TITLE
fix: keep a subtitle language glued to its extension over the common-word filter (#668)

### DIFF
--- a/guessit/rules/properties/language.py
+++ b/guessit/rules/properties/language.py
@@ -562,6 +562,17 @@ class RemoveInvalidLanguages(Rule):
             if match.raw is not None and match.raw.lower() not in self.common_words:
                 continue
 
+            # A language code glued to a subtitle extension (".no.srt") is a deliberate subtitle
+            # tag, not a stray common word — keep it even when blacklisted (#668).
+            following = matches.next(match, predicate=lambda m: not m.private and bool(m.value), index=0)
+            if (
+                following is not None
+                and following.name == "container"
+                and "subtitle" in following.tags
+                and not (matches.input_string or "")[match.end : following.start].strip(seps)
+            ):
+                continue
+
             group = matches.markers.at_match(match, index=0, predicate=lambda m: m.name == "group")
             if group and (
                 not matches.range(

--- a/guessit/rules/properties/language.py
+++ b/guessit/rules/properties/language.py
@@ -562,11 +562,15 @@ class RemoveInvalidLanguages(Rule):
             if match.raw is not None and match.raw.lower() not in self.common_words:
                 continue
 
-            # A language code glued to a subtitle extension (".no.srt") is a deliberate subtitle
-            # tag, not a stray common word — keep it even when blacklisted (#668).
+            # A lowercase language code glued to a subtitle extension (".no.srt") is a deliberate
+            # subtitle tag, not a stray common word — keep it even when blacklisted (#668). A
+            # Title-Case token ("Dr.No.srt", "Garfield.It.srt") is the last word of the title, so
+            # the casing check leaves it for the title.
             following = matches.next(match, predicate=lambda m: not m.private and bool(m.value), index=0)
             if (
-                following is not None
+                match.raw is not None
+                and match.raw.islower()
+                and following is not None
                 and following.name == "container"
                 and "subtitle" in following.tags
                 and not (matches.input_string or "")[match.end : following.start].strip(seps)

--- a/guessit/test/rules/language.yml
+++ b/guessit/test/rules/language.yml
@@ -56,3 +56,13 @@
 ? Show.S01E01.DBRETAiL.no.mkv
 : -subtitle_language: Norwegian
   -language: Norwegian
+
+# but a Title-Case token before a subtitle extension is the last title word, not a language
+# ("Dr.No.srt" = the film *Dr. No*, not Norwegian subtitles)
+? Dr.No.srt
+: title: Dr No
+  -subtitle_language: Norwegian
+
+? Garfield.It.srt
+: title: Garfield It
+  -subtitle_language: it

--- a/guessit/test/rules/language.yml
+++ b/guessit/test/rules/language.yml
@@ -45,3 +45,14 @@
 ? French.Kiss.1995.1080p
 : title: French Kiss
   -language: french
+
+# --- #668: a language glued to a subtitle extension is kept even if it is a common word ---
+# ".no.srt" -> Norwegian subtitle (was dropped by RemoveInvalidLanguages as the common word "no")
+? Show.S01E01.DBRETAiL.no.srt
+: subtitle_language: Norwegian
+  episode_title: DBRETAiL
+
+# but the same common-word code before a video extension is still filtered out
+? Show.S01E01.DBRETAiL.no.mkv
+: -subtitle_language: Norwegian
+  -language: Norwegian


### PR DESCRIPTION
## What

Cluster C1 (short token wrongly consumed as language/country). Fixes the core of **#668**: a subtitle language glued to its extension is kept even when it is a blacklisted common word.

`Show.S01E01.DBRETAiL.no.srt` → `subtitle_language: Norwegian` (was dropped, while `…sv.srt` worked).

## Why

`RemoveInvalidLanguages` removes any `language`/`subtitle_language` whose raw form is in `common_words` (`no` is, `sv` is not). That blacklist guards against mid-title false positives, but it also discarded a perfectly reliable subtitle tag: a language code sitting immediately before a `.srt`/`.ass`/… extension.

## How

In `RemoveInvalidLanguages`, skip the common-word removal when the match is immediately followed (separators only) by a subtitle-format container extension. A language code glued to a subtitle extension is a deliberate tag. The same code before a *video* extension is still filtered, so mid-title false positives are unaffected (verified: `…no.mkv` stays unfiltered).

## Tests

- Fixtures in `guessit/test/rules/language.yml`: `…no.srt` → Norwegian (kept), `…no.mkv` → not Norwegian (still filtered).
- Full suite green: **2217 passed, 4 skipped**, no regressions.

## Deferred / out of scope (documented on the issues)

- **#668 (Danish part)** — `.da.srt` is still not detected because `da` is **not in the default `allowed_languages`** (a separate config decision; `da`/"da" is highly ambiguous). The Norwegian complaint — the actual `RemoveInvalidLanguages` over-filtering — is what this PR fixes.
- **#660** (`HI.SCORE.GIRL…` → `language: Hindi`) — `hi` is not a common word, so this needs context-aware protection of a 2-letter language code at the **start of a title** followed by more title words. High regression risk; deferred for dedicated work.
