### PR TITLE
test: regression anchors for ambiguity-prone parsing boundaries

### DIFF
--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4950,6 +4950,21 @@
   screen_size: 720p
   -other: Converted
 
+# regression anchors (#743 boundary): the lone-article merge must stay scoped — an episode_title
+# that merely *ends* with an article must NOT swallow a following real other/proper word into the
+# title (a broadening that did this was withdrawn from PR #838). Assert the property survives.
+? Game.of.Thrones.S01E09.Baelor.The.Real.1080p.BluRay
+: season: 1
+  episode: 9
+  other: Proper
+  -episode_title: Baelor The Real
+
+? Better.Call.Saul.S04E10.Winner.The.Internal.1080p.WEB
+: season: 4
+  episode: 10
+  other: Internal
+  -episode_title: Winner The Internal
+
 # --- #732: a bare "Cam" right after the episode marker is the episode title ---
 # isolated "Cam" (no other release metadata) is reclaimed from source: Camera
 ? Show.S01E01.Cam.mkv

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1975,3 +1975,10 @@
   year: 2019
   release_group: YIFY
   -release_group: YTS.MX
+
+# regression anchor (#743 boundary): a title ending in a (foreign) article must keep a following
+# real edition as a property, not swallow it into the title (a withdrawn broadening did this).
+? Cinema.Paradiso.La.Extended.1988.1080p.BluRay.x264-GRP.mkv
+: year: 1988
+  edition: Extended
+  -title: Cinema Paradiso La Extended

--- a/guessit/test/rules/language.yml
+++ b/guessit/test/rules/language.yml
@@ -66,3 +66,8 @@
 ? Garfield.It.srt
 : title: Garfield It
   -subtitle_language: it
+
+# regression anchor (#668): a lowercase language code before a subtitle extension is kept
+? Show.S01E01.Some.Title.it.srt
+: subtitle_language: Italian
+  episode_title: Some Title


### PR DESCRIPTION
## What

Test-only PR. Adds **regression anchors** at the parsing boundaries where the recent detection fixes each had an edge-case regression that the corpus did **not** cover (each was caught only during review of #836/#837/#838/#839).

## Why

The corpus was silent on these exact patterns, so a regression could (and did) slip through green. These anchors pin the **correct current behaviour** so a future change can't silently break it — in particular a future retry of the withdrawn #838 broadening.

## Anchors added

**Lone-article boundary** (guards `ExtendLoneArticleTitle`, the rule behind #743/#652/#737):
- `Game.of.Thrones.S01E09.Baelor.The.Real…` → keeps `other: Proper`
- `Better.Call.Saul.S04E10.Winner.The.Internal…` → keeps `other: Internal`
- `Cinema.Paradiso.La.Extended.1988…` → keeps `edition: Extended`

These assert the *property survives* (via negation of the swallowed-title form) rather than pinning the exact title, so a genuine future improvement to the dangling article is not blocked.

**Subtitle-language casing** (guards the #668 fix):
- `Show.S01E01.Some.Title.it.srt` → `subtitle_language: Italian` (lowercase code kept)
- (the Title-Case `Dr.No.srt` / `Garfield.It.srt` guards merged in #839 pin the other direction)

## Tests

Test-only; full suite green. No code changes.
