### PR TITLE
test: anchor correct behaviour of shared rules touched by recent fixes

### DIFF
--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5008,3 +5008,15 @@
   season: 3
   episode: 8
   -season: 5
+
+# anchor: the common "season folder + episode-numbered file" layout still combines correctly —
+# season from the directory, episode from the filename (#797 weight change must not break this)
+? Friends S03/Friends - 07 - The One.mkv
+: title: Friends
+  season: 3
+  episode: 7
+
+# anchor: a parent directory still provides the season when the filename carries none
+? The Wire Season 3/The Wire - Episode Name.mkv
+: title: The Wire
+  season: 3

--- a/guessit/test/rules/language.yml
+++ b/guessit/test/rules/language.yml
@@ -71,3 +71,14 @@
 ? Show.S01E01.Some.Title.it.srt
 : subtitle_language: Italian
   episode_title: Some Title
+
+# anchor (#668 boundary): the common-word filter still suppresses a stray language code mid-name
+# in a video file — only a subtitle extension (or a non-common code) keeps it
+? Show.no.Way.Home.2021.1080p.mkv
+: title: Show no Way Home
+  -language: Norwegian
+  -subtitle_language: Norwegian
+
+# anchor: a real (non-common-word) language is unaffected by the filter
+? Show.S01E01.German.1080p.WEB-DL.mkv
+: language: German


### PR DESCRIPTION
## What

Test-only follow-up to #840. Anchors the **other directions** of the shared rules changed by #837 (multi-filepart precedence) and #839 (common-word language filter), so a future edit to those rules can't silently regress the surrounding correct behaviour.

## Anchors

**Precedence (`RemoveLessSpecificSeasonEpisode`):**
- `Friends S03/Friends - 07 - The One.mkv` → `season: 3` (dir) + `episode: 7` (file) — the most common multi-filepart layout still combines correctly.
- `The Wire Season 3/The Wire - Episode Name.mkv` → `season: 3` — a parent directory still supplies the season when the filename carries none.

**Common-word language filter (`RemoveInvalidLanguages`):**
- `Show.no.Way.Home.2021.1080p.mkv` → no language — a stray common-word code mid-name in a *video* file is still suppressed (only a subtitle extension keeps it, per #668).
- `Show.S01E01.German.1080p.WEB-DL.mkv` → `language: German` — a real, non-common language is unaffected.

## Why

Continues the regression-anchor effort: pin the correct behaviour around the fragile, recently-edited rules. Note these are **not** anchors for the still-open deferred bugs (#693/#774/… ) — pinning buggy output as "expected" would lock in the wrong behaviour and block the eventual fix.

## Tests
Test-only; new fixtures pass, full suite green. No code changes.
