### PR TITLE
fix(episode_title): keep title when a release tag follows the episode marker (#775)

### DIFF
--- a/guessit/rules/properties/episode_title.py
+++ b/guessit/rules/properties/episode_title.py
@@ -201,7 +201,17 @@ class EpisodeTitleFromPosition(TitleBaseRule):
 
         crc32 = matches.named("crc32")
 
-        return bool(episode or crc32)
+        if episode or crc32:
+            return True
+
+        # A release tag (REPACK -> Proper, INTERNAL, ...) can sit between the episode marker and
+        # the episode title (upstream #775: "...S00E01.REPACK.Episode.Title..."). Such a tag is the
+        # hole's immediate predecessor, so the adjacency check above misses the marker; look past it.
+        for previous in reversed(matches.range(0, hole.start, lambda m: not m.private and bool(m.value))):
+            if previous.name in ("other", "proper_count"):
+                continue
+            return previous.named(*self.previous_names)
+        return False
 
     def filepart_filter(self, filepart: Match, matches: Matches) -> bool:
         # Filepart where title was found.

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4965,6 +4965,25 @@
   other: Internal
   -episode_title: Winner The Internal
 
+# --- #775: a release tag (REPACK -> Proper, INTERNAL, ...) between the episode marker and the
+# episode title must not hide the title; the tag stays a property and the title is still parsed ---
+? Total.Forgiveness.S00E01.REPACK.Grant.OBrien.Its.All.Love.Full.Stand.up.Set.1080p.DRPO.WEBRip.x265.AAC.2.0-NOXXUS.mkv
+: title: Total Forgiveness
+  season: 0
+  episode: 1
+  episode_title: Grant OBrien Its All Love Full Stand up Set
+  other: [Proper, Rip]
+  proper_count: 1
+  release_group: NOXXUS
+
+? Total.Forgiveness.S00E01.INTERNAL.Grant.OBrien.1080p.x265-NOXXUS.mkv
+: title: Total Forgiveness
+  season: 0
+  episode: 1
+  episode_title: Grant OBrien
+  other: Internal
+  release_group: NOXXUS
+
 # --- #732: a bare "Cam" right after the episode marker is the episode title ---
 # isolated "Cam" (no other release metadata) is reclaimed from source: Camera
 ? Show.S01E01.Cam.mkv


### PR DESCRIPTION
## Problem

When a release tag (`REPACK` → `Proper`, `INTERNAL`, …) sits **between the episode marker and the episode title**, the entire `episode_title` disappears:

```
Total.Forgiveness.S00E01.REPACK.Grant.OBrien.Its.All.Love.Full.Stand.up.Set.1080p...
  -> episode_title missing  (other: [Proper, Rip])
```

## Root cause

`EpisodeTitleFromPosition.hole_filter` only inspected the hole's **immediately adjacent** predecessor (`matches.previous` stops at the nearest match). That predecessor was the release tag itself, so the episode marker was never found and the title hole was rejected.

## Fix

Look past `other`/`proper_count` tags when checking that the title hole is anchored to an episode marker. The tag stays a property; the title is parsed again.

## Tests

Two regression fixtures added to `episodes.yml` (REPACK and INTERNAL variants). Existing anchors `Baelor.The.Real` / `Winner.The.Internal` unchanged. `uv run pytest`, `ruff`, `mypy` all green.

Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)