### PR TITLE
fix(api,release_group): clear error on None input and stable release-group casing (#803, #776)

### DIFF
--- a/guessit/api.py
+++ b/guessit/api.py
@@ -232,6 +232,10 @@ class GuessItApi:
         :return:
         :rtype:
         """
+        if string is None:
+            # A bare None is almost always an accidental call (e.g. a missing filename); fail with a
+            # clear message instead of the cryptic internal error report wrapped by GuessitException.
+            raise TypeError("guessit() requires a filename string, got None")
         if isinstance(string, Path):
             try:
                 # Handle path-like object

--- a/guessit/rules/processors.py
+++ b/guessit/rules/processors.py
@@ -79,7 +79,15 @@ class EquivalentHoles(Rule):
                         if isinstance(current_match.value, str) and hole.value.lower() == current_match.value.lower():
                             if "equivalent-ignore" in current_match.tags:
                                 continue
-                            new_value = _preferred_string(hole.value, current_match.value)
+                            # A release group keeps the casing of the actual match (typically the
+                            # scene tag at the end of the filename); a parent folder with a different
+                            # casing must not override it (upstream #776). _preferred_string favours
+                            # lower-case over upper-case, which is right for titles but wrong here.
+                            new_value = (
+                                current_match.value
+                                if name == "release_group"
+                                else _preferred_string(hole.value, current_match.value)
+                            )
                             if hole.value != new_value:
                                 hole.value = new_value
                             if current_match.value != new_value:

--- a/guessit/test/test_api.py
+++ b/guessit/test/test_api.py
@@ -39,6 +39,12 @@ def test_pathlike_object() -> None:
     assert "title" in ret
 
 
+def test_none_input() -> None:
+    with pytest.raises(TypeError) as excinfo:
+        guessit(None)  # type: ignore[arg-type]
+    assert "None" in str(excinfo.value)
+
+
 def test_unicode_japanese() -> None:
     ret = guessit("[阿维达].Avida.2006.FRENCH.DVDRiP.XViD-PROD.avi")
     assert ret

--- a/guessit/test/various.yml
+++ b/guessit/test/various.yml
@@ -1453,3 +1453,15 @@
 : title: Movie
   screen_size: 1080p
   -season: 1920
+
+# --- #776: a release group casing must follow the actual match (the scene tag at the end of the
+# filename), not a parent folder with a different casing ---
+? /mnt/user/noxxus/Hellboy.2019.1080p.BluRay.x265-NOXXUS.mkv
+: title: Hellboy
+  year: 2019
+  release_group: NOXXUS
+
+? /mnt/user/noXxus/Hellboy.2019.1080p.BluRay.x265-NOXXUS.mkv
+: title: Hellboy
+  year: 2019
+  release_group: NOXXUS


### PR DESCRIPTION
Two small, unrelated reported defects.

## #803 — cryptic error when `None` is the input

`guessit(None)` raised a `GuessitException` with the full "please report" internal-error dump. `None` is almost always an accidental call, so it now raises a clear `TypeError` up front. Other invalid types still go through the `GuessitException` reporting path (covered by `test_exception`).

## #776 — release-group casing from a parent folder

A parent folder repeating the release group with a different casing overrode the scene tag casing:

```
/mnt/user/noxxus/Hellboy.2019.1080p.BluRay.x265-NOXXUS.mkv
  -> release_group: "noxxus"   (expected "NOXXUS")
```

`EquivalentHoles` normalised the value via `_preferred_string`, which favours lower-case over upper-case — correct for titles, wrong for release groups (scene groups are conventionally upper-case). For `release_group` we now keep the actual match's casing.

## Tests

- `test_none_input` (`TypeError` on `None`)
- two `various.yml` fixtures for the folder-casing case

`uv run pytest`, `ruff`, `mypy` all green.

Closes #803
Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)