### PR TITLE
fix(title): keep trailing "Us" in a title ending on "of" (#739)

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -42,18 +42,6 @@ Schmigadoon.S02E04.Something.Real.1080p.ATVP.WEB-DL.DDP5.1.H.264-NOGRP
   wanted -> episode_title: "Something Real"  (no other)
 ```
 
-### #739 — a title ending in `Us` read as the US country
-
-```
-The.Last.of.Us.S01E01
-  title: "The Last of"   country: US                       (wrong)
-  wanted -> title: "The Last of Us"
-```
-
-`Us` at the title tail is identical to the `US` country keyword. The standalone case is handled
-(`Us.2019` → title `Us`), but a title that *ends* with `Us` after other words still loses it to the
-country match — the same content-vs-property ambiguity as above.
-
 **Root cause.** `Converted` (`CONVERT`) and `Real`/`Proper` are `has-neighbor` `other` keywords. With
 a neighbour present they match wherever they appear, including mid-title.
 

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -47,7 +47,10 @@ RELEASE_TAG_MARKERS = ("release-group-prefix", "streaming_service.prefix", "stre
 # ("with" for "It Ends With Us" #789, "no" for "Oshi no Ko" #745). Other prepositions
 # (in/of/to/at/by/...) are excluded to avoid swallowing a genuine trailing country tag
 # such as "Shameless.in.Us" (where ".Us" is the country variant, not part of the title).
-TITLE_STOP_WORDS = frozenset({"the", "a", "an", "le", "la", "les", "el", "de", "du", "des", "with", "no"})
+# Words a title can legitimately end on before a Title-Case token that merely looks like a
+# country/language ("It Ends With Us", "The Last of Us"). Kept deliberately small: "in" is
+# excluded so "Shameless.in.Us" still resolves country US (see episodes.yml regression anchor).
+TITLE_STOP_WORDS = frozenset({"the", "a", "an", "le", "la", "les", "el", "de", "du", "des", "with", "of", "no"})
 
 
 def title(config: dict[str, Any]) -> Rebulk:

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4933,13 +4933,22 @@
   episode: 3
 
 # #812 review: a trailing country tag after a non-target preposition stays country
-# (only "with"/"no" trigger the stop-word merge), and a bracketed [Us] is never merged
+# ("in" does NOT trigger the stop-word merge), and a bracketed [Us] is never merged
 ? Shameless.in.Us.S01E01.mkv
 : title: Shameless in
   country: US
   season: 1
   episode: 1
   -title: Shameless in Us
+
+# #739: a title ending on a stop-word + Title-Case "Us" keeps "Us" in the title (like #789
+# "It Ends With Us"); "of" triggers the KeepTrailingStopWordTitle merge
+? The.Last.of.Us.S01E01.1080p.mkv
+: title: The Last of Us
+  season: 1
+  episode: 1
+  screen_size: 1080p
+  -country: US
 
 # --- #743: a lone article episode_title swallows the following "other" word ---
 # "The" + other "Converted" -> episode_title "The Convert" (ExtendLoneArticleTitle)

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1982,3 +1982,10 @@
 : year: 1988
   edition: Extended
   -title: Cinema Paradiso La Extended
+
+# #739: a movie title ending on a stop-word + Title-Case "Us" keeps "Us" in the title
+? The.Last.of.Us.2023.1080p.BluRay.x264-GROUP.mkv
+: title: The Last of Us
+  year: 2023
+  release_group: GROUP
+  -country: US


### PR DESCRIPTION
\`The.Last.of.Us.S01E01\` was parsed as title **"The Last of"** + **country US**.

\`KeepTrailingStopWordTitle\` already merges a trailing Title-Case country/language back into the title when the title ends on a stop-word — that's what makes **It Ends With Us** (#789) work via \`with\`. \`of\` was simply missing from \`TITLE_STOP_WORDS\`.

### Fix
Add \`of\` to the set. Same mechanism, exactly analogous to the \`with\` fix.

### Guards preserved
- \`in\` stays **excluded**, so \`Shameless.in.Us.S01E01\` still resolves \`country: US\` (existing regression anchor `episodes.yml`).
- Uppercase tags (\`The.Office.US\`, \`Shameless.US\`) are untouched — the rule only fires on Title-Case \`Us\`.

### Tests / docs
- New fixtures: \`The.Last.of.Us.S01E01\` (episode) + \`The.Last.of.Us.2023…\` (movie), both asserting \`-country: US\`.
- Removed the \`#739\` entry from \`docs/known-limitations.md\` (no longer a limitation).
- Full suite green (2256 passed), ruff + mypy clean.

Closes #739
🤖 Generated with [Claude Code](https://claude.com/claude-code)