### PR TITLE
feat(title): align TITLE_STOP_WORDS with guessit-js (full set)

### DIFF
--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -43,10 +43,37 @@ RELEASE_TAG_MARKERS = ("release-group-prefix", "streaming_service.prefix", "stre
 
 # Stop-words a title may legitimately end on: refuse cropping a trailing Title-Case
 # language/country that would otherwise leave the title ending on one of these
-# ("It Ends With Us" #789, "The Last of Us" #739, "Oshi no Ko" #745). Kept deliberately
-# narrow — "in" is excluded so "Shameless.in.Us" still resolves country US (see the
-# regression anchor in episodes.yml).
-TITLE_STOP_WORDS = frozenset({"the", "a", "an", "le", "la", "les", "el", "de", "du", "des", "with", "of", "no"})
+# ("It Ends With Us" #789, "The Last of Us" #739, "Oshi no Ko" #745). Kept in sync with
+# guessit-js (src/rules/properties/title.ts) for parity. An uppercase tag ("...US") is still
+# kept as a country by the Title-Case guard in KeepTrailingStopWordTitle.
+TITLE_STOP_WORDS = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "of",
+        "to",
+        "in",
+        "on",
+        "at",
+        "for",
+        "from",
+        "by",
+        "with",
+        "into",
+        "onto",
+        "no",
+        "le",
+        "la",
+        "les",
+        "de",
+        "du",
+        "des",
+        "el",
+    }
+)
 
 
 def title(config: dict[str, Any]) -> Rebulk:

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4932,11 +4932,18 @@
   season: 1
   episode: 3
 
-# #812 review: a trailing country tag after a non-target preposition stays country
-# ("in" does NOT trigger the stop-word merge), and a bracketed [Us] is never merged
+# #812 parity (guessit-js stop-word set): a preposition like "in" before a Title-Case "Us"
+# keeps it in the title; only an uppercase tag (The.Office.US above) or a bracketed [Us]
+# stays a country.
 ? Shameless.in.Us.S01E01.mkv
-: title: Shameless in
-  country: US
+: title: Shameless in Us
+  season: 1
+  episode: 1
+  -country: US
+
+# guard: a bracketed [Us] is a deliberate country tag, never merged into the title
+? Shameless.in.[Us].S01E01.mkv
+: country: US
   season: 1
   episode: 1
   -title: Shameless in Us


### PR DESCRIPTION
Brings the trailing-title stop-word set to **full parity with guessit-js** (`src/rules/properties/title.ts`): adds `and, or, to, in, on, at, for, from, by, into, onto` on top of the existing words.

### Effect
A Title-Case country/language after any of these prepositions is now kept in the title:

```
Shameless.in.Us.S01E01.mkv   ->  title "Shameless in Us"   (was: title "Shameless in" + country US)
```

This matches guessit-js, which includes `in`/`of`/`with` in its set.

### Guards preserved
- Uppercase tags stay country: `Shameless.US`, `The.Office.US` → `country: US`.
- Bracketed `[Us]` stays country (deliberate tag): `Shameless.in.[Us]` → `country: US`.

### Tests
- Inverted the `Shameless.in.Us` regression anchor to the aligned result.
- Added a bracketed-`[Us]` guard fixture.
- Full suite green (2257 passed), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)