### PR TITLE
feat(episode_title): title from parent directory for absolute-numbered episodes

### DIFF
--- a/guessit/rules/properties/episode_title.py
+++ b/guessit/rules/properties/episode_title.py
@@ -385,6 +385,14 @@ class Filepart2EpisodeTitle(Rule):
 
     If BBBB contains season and episode and AAA contains a hole
     then title is to be found in AAAA.
+
+    or (absolute numbering, common for anime)
+
+    Serie name/01 - episode_title.mkv
+    AAAAAAAAAA/BBBBBBBBBBBBBBBBBBBB
+
+    If BBBB contains an episode and no season exists anywhere
+    then title is to be found in AAAA.
     """
 
     consequence = AppendMatch("title")
@@ -405,7 +413,8 @@ class Filepart2EpisodeTitle(Rule):
             season = matches.range(
                 directory.start, directory.end, lambda match: match.name == "season", 0
             ) or matches.range(filename.start, filename.end, lambda match: match.name == "season", 0)
-            if season:
+            # Absolute numbering (no season anywhere) still puts the title in the parent directory.
+            if season or not matches.named("season"):
                 hole = matches.holes(
                     directory.start,
                     directory.end,

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5055,3 +5055,11 @@
 ? The Wire Season 3/The Wire - Episode Name.mkv
 : title: The Wire
   season: 3
+
+# #777 (by @zoriya): absolute episode numbering with the title in the parent directory
+? video/zettai karen children/01 - Absolutely Lovely! Their Name Is The Children.mkv
+: title: zettai karen children
+  episode: 1
+  episode_title: Absolutely Lovely! Their Name Is The Children
+  container: mkv
+  type: episode


### PR DESCRIPTION
Re-implements #777 by @zoriya on the current codebase (the original predated the typing/test migration and shipped an unrelated `shell.nix`, dropped here).

Anime are often `Serie name/01 - Episode name.mkv` — absolute numbering, no season. `Filepart2EpisodeTitle` now also fires when the filename has an episode and **no season exists anywhere**, taking the title from the parent directory:

```
video/zettai karen children/01 - Absolutely Lovely! ... .mkv
  -> title: zettai karen children, episode: 1, episode_title: Absolutely Lovely! ...
```

No regression (`Downloads/Show.Name.E05` still titles from the filename). Full suite green (2267).

Supersedes #777 — @zoriya credited as co-author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)