### PR TITLE
fix(numeral): initialise word-numeral regex to "" (Nuitka workaround)

### DIFF
--- a/guessit/rules/common/numeral.py
+++ b/guessit/rules/common/numeral.py
@@ -95,7 +95,9 @@ def __build_word_numeral(*args: list[str]) -> str:
     :return:
     :rtype:
     """
-    re_: str | None = None
+    # Initialise to "" rather than None: Nuitka miscompiles the None branch here
+    # (Nuitka#2101), and an empty string keeps the same first-iteration behaviour.
+    re_ = ""
     for word_list in args:
         for word in word_list:
             if not re_:
@@ -103,7 +105,6 @@ def __build_word_numeral(*args: list[str]) -> str:
             else:
                 re_ += "|"
             re_ += word
-    assert re_ is not None
     re_ += ")"
     return re_
 


### PR DESCRIPTION
Re-implements #781 by @iamkroot on the current codebase.

`__build_word_numeral` initialised its accumulator to `None`, which Nuitka miscompiles ([Nuitka#2101](https://github.com/Nuitka/Nuitka/issues/2101)). Initialise to `""` instead — identical first-iteration behaviour, and the type is now plainly `str` (drops the `| None` + assert). Helps the standalone-binary build (#704).

Full suite green (2267), ruff + mypy clean.

Supersedes #781 — @iamkroot credited as co-author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)