### PR TITLE
fix(episodes): -t episode no longer steals a release-group digit prefix (#627)

### DIFF
--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -354,12 +354,16 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     ).repeater("?").regex(r"(?P<episodeSeparator>[x-])(?P<episode>\d{3,4})", abbreviations=None).repeater("*")
 
     # 1, 2, 3
+    # The negative lookahead keeps a lone digit immediately glued to a "-<word>" out of the
+    # episode list: that digit is the prefix of a dash-separated release group (e.g. the
+    # obfuscation prefix in "x264.1-URANiME-Obfuscated", #627), not a single-digit episode.
+    # A range ("1-2", digit-dash-digit) is unaffected.
     rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
         tags=["weak-episode"],
         disabled=lambda context: context.get("type") != "episode" or is_disabled(context, "episode"),
-    ).defaults(validator=None, tags=["weak-episode"]).regex(r"(?P<episode>\d)").regex(r"v(?P<version>\d+)").repeater(
-        "?"
-    ).regex(r"(?P<episodeSeparator>[x-])(?P<episode>\d{1,2})", abbreviations=None).repeater("*")
+    ).defaults(validator=None, tags=["weak-episode"]).regex(r"(?P<episode>\d)(?!-[a-z])", abbreviations=None).regex(
+        r"v(?P<version>\d+)"
+    ).repeater("?").regex(r"(?P<episodeSeparator>[x-])(?P<episode>\d{1,2})", abbreviations=None).repeater("*")
 
     # e112, e113, 1e18, 3e19
     rebulk.chain(disabled=lambda context: is_disabled(context, "episode")).defaults(validator=None).regex(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5063,3 +5063,15 @@
   episode_title: Absolutely Lovely! Their Name Is The Children
   container: mkv
   type: episode
+
+# #627: with `-t episode`, the single-digit episode rule must not steal the digit prefix of an
+# obfuscated dash-separated release group ("...x264.1-URANiME-Obfuscated"). Result matches auto.
+? Kemono.Michi.Rise.Up.E03.1080p.WEB.x264.1-URANiME-Obfuscated
+: options: -t episode
+  title: Kemono Michi Rise Up
+  episode: 3
+  release_group: 1-URANiME
+  source: Web
+  video_codec: H.264
+  other: Obfuscated
+  -episode_title: URANiME


### PR DESCRIPTION
`guessit -t episode` returned a different (worse) result than auto-detection:

```
auto:        episode: 3,      release_group: "1-URANiME"
-t episode:  episode: [3, 1], episode_title: "URANiME"   (no release_group)
  on  Kemono.Michi.Rise.Up.E03.1080p.WEB.x264.1-URANiME-Obfuscated
```

`-t episode` enables the single-digit episode rule, which grabbed the `1` of the obfuscation prefix `1-URANiME`, breaking the release group.

### Fix
A negative lookahead on the single-digit episode pattern: a lone digit glued to `-<word>` is a release-group prefix, **not** a single-digit episode. A range (`1-2`, digit-dash-digit) is unaffected, as are normal single-digit episodes (`Anime - 5`, `Show.1.720p`). `-t episode` and auto now return the **same** result.

Regression fixture added (with `options: -t episode`). Full suite green (2267), ruff + mypy clean.

Closes #627
🤖 Generated with [Claude Code](https://claude.com/claude-code)