### PR TITLE
fix(screen_size): tolerate trailing "up" upscaled marker (closes #741)

### DIFF
--- a/guessit/rules/properties/screen_size.py
+++ b/guessit/rules/properties/screen_size.py
@@ -51,6 +51,7 @@ def screen_size(config: dict[str, Any]) -> Rebulk:
     progressive_pattern = build_or_pattern(progressive, name="height")
 
     res_pattern = r"(?:(?P<width>\d{3,4})(?:x|\*|×))?"  # noqa: RUF001  # U+00D7 resolution separator
+    upscaled = r"(?:up)?"  # tolerate a trailing "up" (upscaled) marker glued to the resolution (#741)
     rebulk.regex(res_pattern + interlaced_pattern + r"(?P<scan_type>i)" + frame_rate_pattern + "?")
     rebulk.regex(res_pattern + progressive_pattern + r"(?P<scan_type>p)" + frame_rate_pattern + "?")
     rebulk.regex(res_pattern + progressive_pattern + r"(?P<scan_type>p)?(?:hd)")
@@ -61,7 +62,7 @@ def screen_size(config: dict[str, Any]) -> Rebulk:
         conflict_solver=lambda match, other: "__default__" if other.name == "screen_size" else match,
     )
     rebulk.regex(
-        r"(?P<width>\d{3,4})-?(?:x|\*|×)-?(?P<height>\d{3,4})",  # noqa: RUF001  # U+00D7 separator
+        r"(?P<width>\d{3,4})-?(?:x|\*|×)-?(?P<height>\d{3,4})" + upscaled,  # noqa: RUF001  # U+00D7 separator
         conflict_solver=lambda match, other: "__default__" if other.name == "screen_size" else other,
     )
 

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -668,6 +668,19 @@
   screen_size: 720p
   title: Happiness Charge Precure
 
+# #741: a trailing "up" (upscaled) marker glued to a WxH resolution must still resolve to the
+# screen_size; the malformed token must not be left over to shadow the real release group [BOIL].
+? '[BOIL] Inazuma Eleven - Choujigen Dream Match (DVDrip 1280x720up) [B97A2B39].mkv'
+: title: Inazuma Eleven
+  episode_title: Choujigen Dream Match
+  source: DVD
+  other: Rip
+  screen_size: 720p
+  release_group: BOIL
+  crc32: B97A2B39
+  container: mkv
+  type: episode
+
 ? "[Daisei] Free!：Iwatobi Swim Club - 01 ~ (BD 720p 10-bit AAC) [99E8E009].mkv"
 : audio_codec: AAC
   crc32: 99E8E009

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -2005,3 +2005,13 @@
   source: Laserdisc
   video_codec: H.264
   -other: Rip
+
+# #79: a weak "LiNE" token mid-name must not truncate the title; the whole title is kept.
+? Dr.Line.Seuss.The.Lorax.2012.DVDRip.LiNE.XviD.AC3.HQ.Hive-CM8.mp4
+: title: Dr Line Seuss The Lorax
+  year: 2012
+  source: DVD
+  video_codec: Xvid
+  audio_codec: Dolby Digital
+  release_group: Hive-CM8
+  type: movie

--- a/guessit/test/various.yml
+++ b/guessit/test/various.yml
@@ -947,6 +947,13 @@
   audio_codec: DTS-HD
   type: movie
 
+# #693: a decimal frame rate with an FPS suffix must be read as frame_rate, not split into
+# season/episode numbers ("23.976" -> S9 E[23,76]).
+? Gladiator 23.976 FPS
+: title: Gladiator
+  frame_rate: 23.976fps
+  type: movie
+
 ? Mr Robot - S03E01 - eps3 0 power-saver-mode h (1080p AMZN WEB-DL x265 HEVC 10bit EAC3 6.0 RCVR).mkv
 : title: Mr Robot
   season: 3


### PR DESCRIPTION
## What

Fixes #741: a "WxH" resolution glued to an `up` (upscaled) marker — e.g. `1280x720up` — was not detected as a `screen_size` because the trailing `up` broke the `seps_surround` validator. The malformed token was then left over and grabbed as the `release_group`, **shadowing the real group** `[BOIL]` and flipping the result to `type: movie`.

```
[BOIL] Inazuma Eleven - Choujigen Dream Match (DVDrip 1280x720up) [B97A2B39].mkv
  before -> release_group: "1280x720up"   type: movie   (no screen_size)
  after  -> screen_size: 720p   release_group: BOIL   type: episode
```

The fix appends an optional `(?:up)?` to the explicit `WxH` regex in `screen_size.py`, so the resolution still resolves to `720p` and the leftover no longer steals the group.

## Regression anchors for two already-fixed reports

While triaging the batch, two reports already parse correctly on `develop`; this PR locks them with corpus anchors:

- **#79** — a weak `LiNE` token mid-name must not truncate the title (`Dr.Line.Seuss.The.Lorax.2012…` → full title `Dr Line Seuss The Lorax`).
- **#693** (FPS variant) — `Gladiator 23.976 FPS` → `frame_rate: 23.976fps`, not a season/episode split.

## Tests

`uv run pytest` → **2271 passed, 4 skipped**. `ruff` + `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSN8U8jMGw791gxpVpRh6f
