### PR TITLE
feat(other): detect DoVi as Dolby Vision

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -544,7 +544,7 @@
         "Hardcoded Subtitles": ["HC", "vost"],
         "Standard Dynamic Range": {"string": "SDR", "tags": "uhdbluray-neighbor"},
         "HDR10": {"regex": "HDR(?:10)?", "tags": "uhdbluray-neighbor"},
-        "Dolby Vision": {"regex": "(?:Dolby-?Vision|DV)", "tags": "uhdbluray-neighbor"},
+        "Dolby Vision": {"regex": "(?:Dolby-?Vision|DoVi|DV)", "tags": "uhdbluray-neighbor"},
         "BT.2020": {"regex": "BT-?2020","tags": "uhdbluray-neighbor"},
         "Sample": {"string": "Sample", "tags": ["at-end", "not-a-release-group"]},
         "Extras": [

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1322,6 +1322,19 @@
   release_group: ASDF
   type: movie
 
+? Some.Movie.2017.2160p.UHD.BluRay.DTS-HD.MA.5.1.DoVi.x265-NoGroup
+: title: Some Movie
+  year: 2017
+  screen_size: 2160p
+  source: Ultra HD Blu-ray
+  audio_codec: DTS-HD
+  audio_profile: Master Audio
+  audio_channels: '5.1'
+  other: [Dolby Vision]
+  video_codec: H.265
+  release_group: NoGroup
+  type: movie
+
 ? How To Steal A Dog.2014.BluRay.1080p.12bit.HEVC.OPUS 5.1-Hn1Dr2.mkv
 : title: How To Steal A Dog
   year: 2014


### PR DESCRIPTION
## Summary
The `Dolby Vision` `other` pattern already matched `Dolby Vision` and `DV`, but not the equally common `DoVi` abbreviation, which fell through unmatched (parsed as nothing / stolen by neighbours).

This adds `DoVi` to the existing regex: `(?:Dolby-?Vision|DoVi|DV)`.

## Scope notes
- Left `DL DV` / `SL DV` untouched — the reporter confirmed these are no longer used, and `DL` → `Multiple languages` is the intended German-scene "Dual Language" behaviour.
- The `uhdbluray-neighbor` tag only relaxes the "UHD Blu-ray" neighbour check; it does not gate the Dolby Vision match (validated by `seps_surround`), so `DoVi` matches wherever a separate token, with no title false-positive risk.

## Tests
- Added a `DoVi` regression entry to `movies.yml`.
- Full suite green: 2216 passed (incl. `test_yml` + `test_schema`; "Dolby Vision" was already in the schema enum, no regen needed).

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)