### PR TITLE
fix(title): keep dash-joined parent-directory title whole (#796)

### DIFF
--- a/guessit/rules/properties/episode_title.py
+++ b/guessit/rules/properties/episode_title.py
@@ -22,6 +22,42 @@ if TYPE_CHECKING:
     from rebulk.match import Match, Matches
 
 
+def _parent_title_hole(matches: Matches, start: int, end: int) -> Match | None:
+    """Title hole in a parent filepart, keeping a dash-joined name (e.g. "Adam-12") whole.
+
+    ``matches.holes`` splits on ``title_seps`` (the dash included), so without this a
+    name like "Adam-12" is truncated to its first hole "Adam"; merge the consecutive
+    leading holes joined by a single "-" the same way :class:`TitleBaseRule` does when it
+    builds a title in place (upstream #796).
+    """
+    holes = matches.holes(
+        start,
+        end,
+        ignore=or_(lambda match: "weak-episode" in match.tags, TitleBaseRule.is_ignored),
+        formatter=cleanup,
+        seps=title_seps,
+        predicate=lambda match: match.value,
+    )
+    if not holes:
+        return None
+    hole = holes[0]
+    input_string = matches.input_string or ""
+    for next_hole in holes[1:]:
+        separator = input_string[hole.end : next_hole.start]
+        if (
+            len(separator) == 1
+            and separator == "-"
+            and hole.raw is not None
+            and hole.raw[-1] not in seps
+            and next_hole.raw is not None
+            and next_hole.raw[0] not in seps
+        ):
+            hole.end = next_hole.end
+        else:
+            break
+    return hole
+
+
 def episode_title(config: dict[str, Any]) -> Rebulk:
     """
     Builder for rebulk object.
@@ -354,15 +390,7 @@ class Filepart3EpisodeTitle(Rule):
             season = matches.range(directory.start, directory.end, lambda match: match.name == "season", 0)
 
             if season:
-                hole = matches.holes(
-                    subdirectory.start,
-                    subdirectory.end,
-                    ignore=or_(lambda match: "weak-episode" in match.tags, TitleBaseRule.is_ignored),
-                    formatter=cleanup,
-                    seps=title_seps,
-                    predicate=lambda match: match.value,
-                    index=0,
-                )
+                hole = _parent_title_hole(matches, subdirectory.start, subdirectory.end)
                 if hole:
                     return hole
         return None
@@ -415,15 +443,7 @@ class Filepart2EpisodeTitle(Rule):
             ) or matches.range(filename.start, filename.end, lambda match: match.name == "season", 0)
             # Absolute numbering (no season anywhere) still puts the title in the parent directory.
             if season or not matches.named("season"):
-                hole = matches.holes(
-                    directory.start,
-                    directory.end,
-                    ignore=or_(lambda match: "weak-episode" in match.tags, TitleBaseRule.is_ignored),
-                    formatter=cleanup,
-                    seps=title_seps,
-                    predicate=lambda match: match.value,
-                    index=0,
-                )
+                hole = _parent_title_hole(matches, directory.start, directory.end)
                 if hole:
                     hole.tags.append("filepart-title")
                     return hole

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4885,6 +4885,17 @@
   -release_group: Adam
   -alternative_title: '12'
 
+# the title from the parent directory must keep the dash-joined name whole too,
+# so it collapses with the filename title instead of returning ['Adam', '12'] (upstream #796)
+? Adam-12 1968 Season 1 Complete x264 [i_c]/Adam-12 S01E02 Log 141 The Color TV Bandit.mkv
+: title: Adam-12
+  year: 1968
+  season: 1
+  episode: 2
+  episode_title: Log 141 The Color TV Bandit
+  -title: Adam
+  -alternative_title: '12'
+
 # a real leading scene group followed by a multi-word title + episode is still detected
 # (the hyphenated-title guard must only fire for a single dash-joined word)
 ? FoV-Show.Name.S01E01.720p.HDTV.x264.mkv


### PR DESCRIPTION
## Contexte

Fixes #796.

`guessit "Adam-12 1968 Season 1 Complete x264 [i_c]/Adam-12 S01E02 Log 141 The Color TV Bandit.mkv"` renvoyait `title: ["Adam", "12"]` (une liste) au lieu de `"Adam-12"`, ce qui faisait planter `subliminal` (qui attend une string).

## Diagnostic

- Le fichier seul et le dossier seul donnaient déjà `Adam-12` correctement ; le bug n'apparaissait qu'en **mode chemin** (dossier + fichier).
- Le titre était alors extrait du dossier parent par `Filepart2EpisodeTitle` / `Filepart3EpisodeTitle`, qui calculaient le trou avec `seps=title_seps`. Comme `title_seps` contient le tiret, `Adam-12` était coupé et `index=0` ne gardait que `"Adam"`.
- `TitleBaseRule` re-fusionne déjà les noms séparés par un seul `-`, mais ces règles `episode_title` ne le faisaient pas → incohérence.
- En cascade : `"Adam"` (dossier) différait de `"Adam-12"` (fichier), donc `PreferTitleWithYear` (dédup par valeur) ne pouvait pas les fusionner → liste finale.

## Correctif

- Helper partagé `_parent_title_hole()` qui calcule le trou du titre parent en re-fusionnant les tirets, comme `TitleBaseRule`.
- Appliqué à `Filepart2EpisodeTitle` et `Filepart3EpisodeTitle`.
- Résultat : le dossier donne `"Adam-12"`, identique au titre du fichier → collapse en une seule string `"Adam-12"`.

## Tests

- Nouvelle fixture dans `episodes.yml` pour le cas complet du ticket.
- Suite complète : `2273 passed, 4 skipped` ; ruff et mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)