### PR TITLE
fix(date): absorb a weekday glued to a date so episode_title survives (#794)

### DIFF
--- a/guessit/api.py
+++ b/guessit/api.py
@@ -113,7 +113,7 @@ def _complete_properties(ordered: dict[str, Any]) -> dict[str, Any]:
 
     Value-constrained properties advertise their full declared enum (unioned with
     whatever introspection found); every other schema property is guaranteed to be
-    present, with ``[None]`` marking a free/computed value. Mirrors guessit-js.
+    present, with ``[None]`` marking a free/computed value.
     """
     for name, spec in GUESSIT_SCHEMA.items():
         current = ordered.get(name) or []

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -881,7 +881,11 @@
       "ZDF": "ZDF"
     },
     "date": {
-      "week_words": ["week"]
+      "week_words": ["week"],
+      "weekday_words": [
+        "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+        "mon", "tue", "tues", "wed", "weds", "thu", "thur", "thurs", "fri", "sat", "sun"
+      ]
     }
   }
 }

--- a/guessit/rules/common/date.py
+++ b/guessit/rules/common/date.py
@@ -26,7 +26,7 @@ date_regexps = [
     re.compile(
         rf"(?:^|[^\d])((\d{{1,2}}(?:st|nd|rd|th)?{_dsep}(?:[a-z]{{3,10}}){_dsep}\d{{4}}))(?:$|[^\d])", re.IGNORECASE
     ),
-    # month-name first, e.g. "July 30 2021" (guessit-js parity, upstream #708)
+    # month-name first, e.g. "July 30 2021" (upstream #708)
     re.compile(
         rf"(?:^|[^a-z\d])(((?:[a-z]{{3,10}}){_dsep}\d{{1,2}}(?:st|nd|rd|th)?{_dsep}\d{{4}}))(?:$|[^\d])", re.IGNORECASE
     ),

--- a/guessit/rules/properties/date.py
+++ b/guessit/rules/properties/date.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 from rebulk import Rebulk, RemoveMatch, Rule
 
 from ...reutils import build_or_pattern
-from ..common import dash
+from ..common import dash, seps
 from ..common.date import search_date, valid_week, valid_year
 from ..common.pattern import is_disabled
 from ..common.validators import seps_surround
@@ -76,9 +76,59 @@ def date(config: dict[str, Any]) -> Rebulk:
         conflict_solver=lambda match, other: other if other.name in ("episode", "season", "crc32") else "__default__",
     )
 
-    rebulk.rules(KeepMarkedYearInFilepart)
+    rebulk.rules(KeepMarkedYearInFilepart, AbsorbWeekdayPrefix(config["weekday_words"]))
 
     return rebulk
+
+
+class AbsorbWeekdayPrefix(Rule):
+    """
+    Absorb a weekday word glued to a date into the ``date`` match (upstream #794).
+
+    ``A.Place.in.the.Sun.S2025E01.Thu.2.Jan.2025.Mar.Menor.Spain...`` parses ``2 Jan 2025`` as the
+    air date but the leading "Thu" is the broadcast weekday, not the title. The interior date splits
+    the title hole in two, so ``EpisodeTitleFromPosition`` fills the first hole ("Thu") and drops the
+    real title after the date ("Mar Menor Spain"). Growing the date span to cover the adjacent weekday
+    removes that first hole, so the title after the date is reclaimed instead.
+
+    Only a weekday directly preceding the date (separators only between, and not already claimed by
+    another match) is absorbed; the parsed date value is unchanged.
+    """
+
+    consequence = RemoveMatch
+
+    def __init__(self, weekday_words: list[str]) -> None:
+        super().__init__()
+        seps_class = "[" + re.escape(seps) + "]"
+        self.weekday_re = re.compile(
+            r"(?:^|" + seps_class + r")(" + build_or_pattern(weekday_words) + r")" + seps_class + r"*$",
+            re.IGNORECASE,
+        )
+
+    def enabled(self, context: dict[str, Any] | None) -> bool:
+        return not is_disabled(context, "date")
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        input_string = matches.input_string or ""
+        ret: list[tuple[Match, int]] = []
+        for date_match in matches.named("date"):
+            filepart = matches.markers.at_match(date_match, lambda m: m.name == "path", 0)
+            lower = filepart.start if filepart else 0
+            weekday = self.weekday_re.search(input_string[lower : date_match.start])
+            if not weekday:
+                continue
+            new_start = lower + weekday.start(1)
+            # Only absorb a free weekday word; never swallow a token already claimed by a match.
+            if matches.range(new_start, date_match.start, predicate=lambda m: not m.private):
+                continue
+            ret.append((date_match, new_start))
+        return ret
+
+    def then(self, matches: Matches, when_response: Any, context: dict[str, Any] | None) -> None:
+        for date_match, new_start in when_response:
+            matches.remove(date_match)
+            date_match.start = new_start
+            matches.append(date_match)
 
 
 class KeepMarkedYearInFilepart(Rule):

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -152,7 +152,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         Validate a season-word number, rejecting a 4-digit year (e.g. "Season 2025").
 
         Only applies to the season WORD chain ("Season N"), not SxxExx, so
-        "S2013E14 -> season 2013" stays unaffected (guessit-js parity, #800).
+        "S2013E14 -> season 2013" stays unaffected (#800).
         """
         raw = match.raw or ""
         if re.match(r"^\d{4}$", raw) and 1900 <= int(raw) <= 2100:

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -43,9 +43,8 @@ RELEASE_TAG_MARKERS = ("release-group-prefix", "streaming_service.prefix", "stre
 
 # Stop-words a title may legitimately end on: refuse cropping a trailing Title-Case
 # language/country that would otherwise leave the title ending on one of these
-# ("It Ends With Us" #789, "The Last of Us" #739, "Oshi no Ko" #745). Kept in sync with
-# guessit-js (src/rules/properties/title.ts) for parity. An uppercase tag ("...US") is still
-# kept as a country by the Title-Case guard in KeepTrailingStopWordTitle.
+# ("It Ends With Us" #789, "The Last of Us" #739, "Oshi no Ko" #745). An uppercase tag
+# ("...US") is still kept as a country by the Title-Case guard in KeepTrailingStopWordTitle.
 TITLE_STOP_WORDS = frozenset(
     {
         "the",

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4784,7 +4784,7 @@
   release_group: NOGRP
   type: episode
 
-# guessit-js parity — a 4-digit year is not a season-word number (#800/#815);
+# a 4-digit year is not a season-word number (#800/#815);
 # with no real season/episode the title falls back to a movie.
 
 ? Show.Name.Season.2025.1080p.WEB-DL.x264-GRP.mkv
@@ -4956,7 +4956,7 @@
   season: 1
   episode: 3
 
-# #812 parity (guessit-js stop-word set): a preposition like "in" before a Title-Case "Us"
+# #812: a preposition like "in" before a Title-Case "Us"
 # keeps it in the title; only an uppercase tag (The.Office.US above) or a bracketed [Us]
 # stays a country.
 ? Shameless.in.Us.S01E01.mkv
@@ -5099,3 +5099,20 @@
   video_codec: H.264
   other: Obfuscated
   -episode_title: URANiME
+
+# #794: a weekday glued to the broadcast date ("Thu.2.Jan.2025") is part of the air-date stamp,
+# not the episode_title; absorbing it into the date frees the real title sitting after the date.
+? A.Place.in.the.Sun.S2025E01.Thu.2.Jan.2025.Mar.Menor.Spain.1080p.ALL4.WEB-DL.AAC2.0.H.264-TBN
+: title: A Place in the Sun
+  season: 2025
+  episode: 1
+  date: 2025-01-02
+  episode_title: Mar Menor Spain
+  screen_size: 1080p
+  streaming_service: Channel 4
+  source: Web
+  audio_codec: AAC
+  audio_channels: '2.0'
+  video_codec: H.264
+  release_group: TBN
+  type: episode

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1894,7 +1894,7 @@
   container: mkv
   type: movie
 
-# guessit-js parity — MicroHD / HDlite regex form (#818)
+# MicroHD / HDlite regex form (#818)
 
 ? Some.Movie.2019.Micro-HD.1080p.x264-GRP.mkv
 : title: Some Movie
@@ -1914,7 +1914,7 @@
   screen_size: 1080p
   type: movie
 
-# guessit-js parity — pre-1920 year accepted (#646/#815)
+# pre-1920 year accepted (#646/#815)
 
 ? The.Immigrant.1917.1080p.BluRay.x264-GRP.mkv
 : title: The Immigrant

--- a/guessit/test/test_archive_metadata.py
+++ b/guessit/test/test_archive_metadata.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Archive / image / artwork container tests (ported from guessit-js).
+"""Archive / image / artwork container tests.
 
 #272 (archive containers) and #273 (metadata/image files): the extension must be
 recognised as a container and must NOT leak into release_group / title / etc.

--- a/guessit/test/test_schema.py
+++ b/guessit/test/test_schema.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Tests for the machine-readable property schema (ported from guessit-js)."""
+"""Tests for the machine-readable property schema."""
 
 from __future__ import annotations
 

--- a/guessit/test/various.yml
+++ b/guessit/test/various.yml
@@ -1205,7 +1205,7 @@
   container: mp4
   type: movie
 
-# guessit-js parity — new property / value extraction (#818)
+# new property / value extraction (#818)
 
 ? Show.Name.vol127.1080p.x264-GRP.mkv
 : title: Show Name
@@ -1300,7 +1300,7 @@
   container: mkv
   type: episode
 
-# guessit-js parity — archive / image containers + artwork (#817)
+# archive / image containers + artwork (#817)
 
 ? Show.Name.S01E01.720p.HDTV.x264-GRP.rar
 : title: Show Name
@@ -1360,7 +1360,7 @@
   container: mkv
   type: movie
 
-# guessit-js parity — every archive/image extension is a container (#817)
+# every archive/image extension is a container (#817)
 # (keeps the container enum code-complete; the extension must not leak)
 
 ? Some.Release.2020.1080p.x264-GRP.7z


### PR DESCRIPTION
## Problem (#794)

```
A.Place.in.the.Sun.S2025E01.Thu.2.Jan.2025.Mar.Menor.Spain.1080p...
→ episode_title: "Thu"   (expected: "Mar Menor Spain")
  date: 2025-01-02
```

`2 Jan 2025` is correctly parsed as the air date (confirmed: this is genuinely the release date), but the leading `Thu` is the broadcast **weekday**, not the title. The interior date splits the title hole in two: `Thu` before it and `Mar Menor Spain` after it. `EpisodeTitleFromPosition` fills the **first** qualifying hole and stops, so `Thu` becomes the `episode_title` and the real title after the date is dropped.

## Fix

New rule `AbsorbWeekdayPrefix` in `date.py`: for each `date` match, if a weekday word directly precedes it (separators only between, and the span is not already claimed by another match), the date span grows to cover the weekday. This removes the first hole so the title after the date is reclaimed. The parsed date value is unchanged.

```
→ episode_title: "Mar Menor Spain"   ✅
  date: 2025-01-02
```

- Weekday vocabulary is config-driven (`date.weekday_words` in `options.json`): full names + common abbreviations.
- Narrow scope: does **not** touch title hole-selection, so the "title before/after a trailing date" families are untouched.
- Covers full names (`Thursday.2.Jan.2025`) and the date-at-end case (where the spurious `Thu` episode_title is no longer emitted).
- A genuine title placed *before* an interior date remains ambiguous and out of scope — only the clear discriminating signal (a weekday glued to the date) is handled.

## Tests / quality

- New regression entry in `episodes.yml` for the exact #794 filename.
- Full suite green: `2274 passed, 4 skipped`; `ruff`, `ruff format`, `mypy --strict` all clean.

## Also in this PR

A small comment-hygiene commit (`docs:`) removing the "guessit-js parity / ported from guessit-js" phrasing from comments, docstrings and YAML annotations, keeping the explanations and issue references intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSN8U8jMGw791gxpVpRh6f