### PR TITLE
feat(other): match opening/ending credits with index and version (#705)

### DIFF
--- a/docs/properties.md
+++ b/docs/properties.md
@@ -114,6 +114,12 @@ Episode properties
     Version of the episode.
 
     -   In anime fansub scene, new versions are released with tag `<episode>v[0-9]`.
+    -   Also applies to opening/ending credit sequences (e.g. `ED2v2`).
+-   **credits\_number**
+
+    Ordinal of an opening/ending credit sequence (see `Opening Credits` /
+    `Ending Credits` in `other`). Kept as a string because of the variant-letter
+    forms (e.g. `2` in `OP02`, `4a` in `OP4a`).
 
 Video properties
 ----------------
@@ -275,5 +281,5 @@ Other properties
 
     Other property will appear under this property.
 
-    -   `2in1`, `3D`, `Audio Fixed`, `Banner`, `Bonus`, `BT.2020`, `Classic`, `Clear Art`, `Clear Logo`, `Colorized`, `Complete`, `Converted`, `Cover`, `Disc Art`, `Documentary`, `Dolby Vision`, `Dual Audio`, `East Coast Feed`, `Ending Credits`, `Extras`, `Fan Subtitled`, `Fanart`, `Fast Subtitled`, `Full HD`, `Hardcoded Subtitles`, `HD`, `HDR10`, `High Frame Rate`, `Hybrid`, `Variable Frame Rate`, `High Quality`, `High Resolution`, `Internal`, `Landscape`, `Line Dubbed`, `Line Audio`, `Logo`, `Mic Dubbed`, `Micro HD`, `Mux`, `NTSC`, `Obfuscated`, `Open Matte`, `Opening Credits`, `Original Aspect Ratio`, `Original Video`, `PAL`, `Poster`, `Preair`, `Proof`, `Proper`, `PS Vita`, `Read NFO`, `Region 5`, `Region C`, `Reencoded`, `Remux`, `Repost`, `Retail`, `Rip`, `Sample`, `Screener`, `SECAM`, `Standard Dynamic Range`, `Straight to Video`, `Sync Fixed`, `Thumbnail`, `Trailer`, `Ultra HD`, `Upscaled`, `Virtual Reality`, `West Coast Feed`, `Widescreen`, `XXX`
+    -   `2in1`, `3D`, `Audio Fixed`, `Banner`, `Bonus`, `BT.2020`, `Classic`, `Clear Art`, `Clear Logo`, `Colorized`, `Complete`, `Converted`, `Cover`, `Creditless`, `Disc Art`, `Documentary`, `Dolby Vision`, `Dual Audio`, `East Coast Feed`, `Ending Credits`, `Extras`, `Fan Subtitled`, `Fanart`, `Fast Subtitled`, `Full HD`, `Hardcoded Subtitles`, `HD`, `HDR10`, `High Frame Rate`, `Hybrid`, `Variable Frame Rate`, `High Quality`, `High Resolution`, `Internal`, `Landscape`, `Line Dubbed`, `Line Audio`, `Logo`, `Mic Dubbed`, `Micro HD`, `Mux`, `NTSC`, `Obfuscated`, `Open Matte`, `Opening Credits`, `Original Aspect Ratio`, `Original Video`, `PAL`, `Poster`, `Preair`, `Proof`, `Proper`, `PS Vita`, `Read NFO`, `Region 5`, `Region C`, `Reencoded`, `Remux`, `Repost`, `Retail`, `Rip`, `Sample`, `Screener`, `SECAM`, `Standard Dynamic Range`, `Straight to Video`, `Sync Fixed`, `Thumbnail`, `Trailer`, `Ultra HD`, `Upscaled`, `Virtual Reality`, `West Coast Feed`, `Widescreen`, `XXX`
 

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -506,8 +506,6 @@
         "2in1": "2in1",
         "3D": {"string": "3D", "tags": "has-neighbor"},
         "Virtual Reality": {"string": ["VR"], "regex": ["VR180", "VR360"], "tags": "has-neighbor"},
-        "Opening Credits": {"string": ["NCOP", "OPED"], "regex": ["NC-?OP", "creditless-?opening"], "tags": "has-neighbor"},
-        "Ending Credits": {"string": ["NCED"], "regex": ["NC-?ED", "creditless-?ending"], "tags": "has-neighbor"},
         "High Quality": {"string": "HQ", "tags": "uhdbluray-neighbor"},
         "High Resolution": "HR",
         "Line Dubbed": "LD",

--- a/guessit/data/output-schema.json
+++ b/guessit/data/output-schema.json
@@ -340,6 +340,9 @@
     "crc32": {
       "type": "string"
     },
+    "credits_number": {
+      "type": "string"
+    },
     "date": {
       "type": "string"
     },
@@ -498,6 +501,7 @@
             "Complete",
             "Converted",
             "Cover",
+            "Creditless",
             "Disc Art",
             "Documentary",
             "Dolby Vision",
@@ -584,6 +588,7 @@
               "Complete",
               "Converted",
               "Cover",
+              "Creditless",
               "Disc Art",
               "Documentary",
               "Dolby Vision",

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -475,10 +475,14 @@ class WeakConflictSolver(Rule):
 
         Anime characteristics:
             - version, crc32 matches
+            - opening/ending credits (NCOP/NCED…), near-exclusive to anime
             - screen_size inside brackets
             - release_group at start and inside brackets
         """
         if matches.named("version") or matches.named("crc32"):
+            return True
+
+        if matches.named("other", predicate=lambda m: m.value in ("Opening Credits", "Ending Credits")):
             return True
 
         for group in matches.markers.named("group"):

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -44,6 +44,7 @@ def other(config: dict[str, Any]) -> Rebulk:
     rebulk.rules(
         RenameAnotherToOther,
         AppendCreditless,
+        AppendOpedEndingCredits,
         ValidateHasNeighbor,
         ValidateHasNeighborAfter,
         ValidateHasNeighborBefore,
@@ -286,6 +287,30 @@ class AppendCreditless(Rule):
             if raw.startswith("nc") or "creditless" in raw:
                 to_append.append(
                     Match(match.start, match.end, name="other", value="Creditless", input_string=matches.input_string)
+                )
+        return to_append
+
+
+class AppendOpedEndingCredits(Rule):
+    """
+    ``OPED`` is the combined opening *and* ending sequence, so it carries both
+    `Opening Credits` (already matched) and `Ending Credits`. This adds the
+    missing `Ending Credits` value over the same span.
+    """
+
+    priority = POST_PROCESS
+    consequence = AppendMatch
+
+    properties = {"other": ["Ending Credits"]}
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        to_append: list[Match] = []
+        for match in matches.named("other", predicate=lambda m: m.value == "Opening Credits"):
+            if re.sub(r"[\s._-]+", "", (match.raw or "").lower()) == "oped":
+                to_append.append(
+                    Match(
+                        match.start, match.end, name="other", value="Ending Credits", input_string=matches.input_string
+                    )
                 )
         return to_append
 

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -39,8 +39,11 @@ def other(config: dict[str, Any]) -> Rebulk:
 
     load_config_patterns(rebulk, config.get("other"))
 
+    opening_ending_credits(rebulk)
+
     rebulk.rules(
         RenameAnotherToOther,
+        AppendCreditless,
         ValidateHasNeighbor,
         ValidateHasNeighborAfter,
         ValidateHasNeighborBefore,
@@ -55,6 +58,62 @@ def other(config: dict[str, Any]) -> Rebulk:
     )
 
     return rebulk
+
+
+#: Ordinal of an opening/ending sequence, e.g. ``2`` in ``OP02`` or ``4a`` in
+#: ``OP4a``. Kept as a string because of the variant-letter forms (``4a``, ``1a``).
+#: The leading version ``v`` is excluded so ``ED2v2`` yields number ``2``, version ``2``.
+#: ``[^\W\d_]`` (a letter) avoids a ``-`` range, which the ``dash`` abbreviation
+#: would otherwise rewrite into a broken nested character set.
+_CREDITS_NUMBER = r"(?P<credits_number>\d+(?:(?![vV]\d)[^\W\d_])?)?"
+#: Optional version suffix glued to an opening/ending token, e.g. ``v2`` in ``ED2v2``.
+_CREDITS_VERSION = r"(?:-?[vV](?P<version>\d+))?"
+_CREDITS_SUFFIX = _CREDITS_NUMBER + _CREDITS_VERSION
+
+
+def _format_credits_number(value: str) -> str:
+    """Normalize an opening/ending ordinal: drop leading zeros, keep the variant letter."""
+    match = re.match(r"(\d+)(\w?)$", value)
+    if not match:
+        return value
+    number, letter = str(match.group(1)), str(match.group(2))
+    return str(int(number)) + letter.lower()
+
+
+def opening_ending_credits(rebulk: Rebulk) -> None:
+    """
+    Match anime opening/ending credit sequences (OP/ED, NCOP/NCED, creditless…).
+
+    Emits ``other: Opening Credits`` / ``Ending Credits`` plus, when present, the
+    sequence ordinal as ``credits_number`` (string, e.g. ``4a``) and the ``version``.
+    The bare two-letter ``OP``/``ED`` tokens are matched case-sensitively (uppercase
+    only) so common mixed-case words such as the name "Ed" are never captured; the
+    unambiguous NC*/creditless forms stay case-insensitive.
+    """
+
+    def add(pattern: str, value: str, *, ignore_case: bool) -> None:
+        rebulk.regex(
+            "(?P<other>" + pattern + ")" + _CREDITS_SUFFIX,
+            flags=re.IGNORECASE if ignore_case else 0,
+            name="other",
+            children=True,
+            private_parent=True,
+            validate_all=True,
+            validator={"__parent__": seps_surround},
+            formatter={
+                "other": lambda _match, value=value: value,
+                "credits_number": _format_credits_number,
+                "version": int,
+            },
+            disabled=lambda context: is_disabled(context, "other"),
+        )
+
+    # NC*/creditless forms are unambiguous — match them case-insensitively.
+    add(r"NC-?OP|creditless-?op(?:ening)?", "Opening Credits", ignore_case=True)
+    add(r"NC-?ED|creditless-?(?:ed|ending)", "Ending Credits", ignore_case=True)
+    # Bare uppercase tokens. OPED is the combined opening+ending sequence (not creditless).
+    add(r"OPED|OP", "Opening Credits", ignore_case=False)
+    add(r"ED", "Ending Credits", ignore_case=False)
 
 
 #: Artwork file-name keywords mapped to their canonical ``other`` value.
@@ -198,6 +257,37 @@ class ImageArtKeywordToOther(Rule):
         if to_remove or to_append:
             return to_remove, to_append
         return None
+
+
+class AppendCreditless(Rule):
+    """
+    Surface a `Creditless` other value for creditless opening/ending tokens.
+
+    The `Opening Credits` / `Ending Credits` matches conflate two facts: which
+    sequence it is (opening vs ending) and whether it is creditless (no text
+    overlay, the ``NC``/``creditless`` forms). This rule keeps opening/ending in
+    its existing match and adds a separate `Creditless` value over the same span
+    so the creditless attribute is distinguishable. The combined ``OPED`` token
+    is opening+ending, not creditless, so it is left untouched.
+
+    Runs at POST_PROCESS so a credits match removed by the has-neighbor
+    validators never leaves an orphan `Creditless` behind.
+    """
+
+    priority = POST_PROCESS
+    consequence = AppendMatch
+
+    properties = {"other": ["Creditless"]}
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        to_append: list[Match] = []
+        for match in matches.named("other", predicate=lambda m: m.value in ("Opening Credits", "Ending Credits")):
+            raw = re.sub(r"[\s._-]+", "", (match.raw or "").lower())
+            if raw.startswith("nc") or "creditless" in raw:
+                to_append.append(
+                    Match(match.start, match.end, name="other", value="Creditless", input_string=matches.input_string)
+                )
+        return to_append
 
 
 class RenameAnotherToOther(Rule):

--- a/guessit/schema.py
+++ b/guessit/schema.py
@@ -139,6 +139,7 @@ GUESSIT_SCHEMA: dict[str, PropertySchema] = {
     },
     "country": {"type": ["Language"], "array": False, "scalar": True},
     "crc32": {"type": ["string"], "array": False, "scalar": True},
+    "credits_number": {"type": ["string"], "array": False, "scalar": True},
     "date": {"type": ["string"], "array": False, "scalar": True},
     "disc": {"type": ["number"], "array": True, "scalar": True},
     "edition": {
@@ -197,6 +198,7 @@ GUESSIT_SCHEMA: dict[str, PropertySchema] = {
             "Complete",
             "Converted",
             "Cover",
+            "Creditless",
             "Disc Art",
             "Documentary",
             "Dolby Vision",

--- a/guessit/test/various.yml
+++ b/guessit/test/various.yml
@@ -1307,12 +1307,15 @@
   container: mkv
   type: episode
 
-# OPED is the combined opening+ending sequence, not a creditless one.
+# OPED is the combined opening+ending sequence (both credits), not creditless.
 ? Show.Name.S01E01.OPED.1080p.x264-GRP.mkv
 : title: Show Name
   season: 1
   episode: 1
-  other: Opening Credits
+  other:
+  - Opening Credits
+  - Ending Credits
+  -other: Creditless
   screen_size: 1080p
   video_codec: H.264
   release_group: GRP

--- a/guessit/test/various.yml
+++ b/guessit/test/various.yml
@@ -1272,7 +1272,9 @@
 : title: Show Name
   season: 1
   episode: 1
-  other: Opening Credits
+  other:
+  - Opening Credits
+  - Creditless
   screen_size: 1080p
   video_codec: H.264
   release_group: GRP
@@ -1283,12 +1285,96 @@
 : title: Show Name
   season: 1
   episode: 1
-  other: Ending Credits
+  other:
+  - Ending Credits
+  - Creditless
   screen_size: 1080p
   video_codec: H.264
   release_group: GRP
   container: mkv
   type: episode
+
+? Show.Name.S01E01.NC-ED.1080p.x264-GRP.mkv
+: title: Show Name
+  season: 1
+  episode: 1
+  other:
+  - Ending Credits
+  - Creditless
+  screen_size: 1080p
+  video_codec: H.264
+  release_group: GRP
+  container: mkv
+  type: episode
+
+# OPED is the combined opening+ending sequence, not a creditless one.
+? Show.Name.S01E01.OPED.1080p.x264-GRP.mkv
+: title: Show Name
+  season: 1
+  episode: 1
+  other: Opening Credits
+  screen_size: 1080p
+  video_codec: H.264
+  release_group: GRP
+  container: mkv
+  type: episode
+
+# Opening/ending sequence ordinal (credits_number) and version.
+? '[FFF] Shingeki no Kyojin - OP02 [BD][1080p-FLAC][40D46701].mkv'
+: title: Shingeki no Kyojin
+  other: Opening Credits
+  credits_number: '2'
+  source: Blu-ray
+  screen_size: 1080p
+  release_group: FFF
+
+? '[Coalgirls]_Bakemonogatari_OP4a_(1920x1080_Blu-ray_FLAC)_[AF4FF3CC].mkv'
+: title: Bakemonogatari
+  other: Opening Credits
+  credits_number: 4a
+  source: Blu-ray
+  release_group: Coalgirls
+
+? Fullmetal_Alchemist_Brotherhood_ED2v2_Clean_[BD_1080p][AtsA][0F81F8F7].mkv
+: title: Fullmetal Alchemist Brotherhood
+  other: Ending Credits
+  credits_number: '2'
+  version: 2
+  source: Blu-ray
+  screen_size: 1080p
+
+# Bare uppercase OP token (anime opening, no ordinal).
+? '[GHOST] Saga of Tanya the Evil - OP [BDRip 1920x1080 x264][FB85D2DA].mkv'
+: title: Saga of Tanya the Evil
+  other:
+  - Opening Credits
+  - Rip
+  release_group: GHOST
+
+# Creditless opening with ordinal, plus the Creditless attribute.
+? Code_Geass_Creditless_OP5_[720p,BluRay,x264]_-_gg-THORA.mkv
+: title: Code Geass
+  other:
+  - Opening Credits
+  - Creditless
+  credits_number: '5'
+  screen_size: 720p
+
+# Creditless ending alongside a real episode number.
+? 'NC/[VCB-Studio] Ishuzoku Reviewers [NCED_EP12][Ma10p_1080p][x265_flac].mkv'
+: title: Ishuzoku Reviewers
+  other:
+  - Ending Credits
+  - Creditless
+  episode: 12
+  release_group: VCB-Studio
+
+# The name "Ed" must not be captured as an Ending Credits token (case-sensitive).
+? Ed.S01E01.1080p.WEB-DL-GRP.mkv
+: title: Ed
+  season: 1
+  episode: 1
+  -other: Ending Credits
 
 ? Show.Name.July.30.2021.1080p.WEB-DL.x264-GRP.mkv
 : title: Show Name


### PR DESCRIPTION
Closes #705.

Anime opening/ending sequences were mostly swallowed into `title` / `episode_title`. They now resolve to the existing `other: Opening Credits` / `Ending Credits` values, with the additions agreed on the ticket (Option A — see [design comment](https://github.com/guessit-io/guessit/issues/705#issuecomment-4827321287)).

## What changed

- **`other: Creditless`** — new enum value, surfaced as a *separate, orthogonal* attribute for the `NC*`/`creditless` forms. A file can be both `Opening Credits` **and** `Creditless`. `OPED` (combined opening+ending) is **not** creditless.
- **`credits_number`** — new `string` property for the sequence ordinal glued to the token: `OP02` → `"2"`, `OP4a` → `"4a"`, `ED1a` → `"1a"` (string because of the variant-letter forms).
- **`version`** — now also captured on credit tokens: `ED2v2` → `version: 2`.
- **`is_anime`** — `WeakConflictSolver` now treats an Opening/Ending Credits match as an anime signal (near-exclusive to anime releases).

## Design notes / deliberate limitations

- Bare two-letter `OP`/`ED` are matched **case-sensitively (uppercase only)** so common mixed-case words like the name *"Ed"* are never captured; the unambiguous `NC*`/`creditless` forms stay case-insensitive.
- A **separator before the ordinal is intentionally not supported** (`NCED 1080p` must not yield number `1080`); only glued ordinals are recognized. This drops the ticket's separated-index examples (`NCED 2`) in favor of safety.
- `extra_type`/`extra_index` from the original proposal were **dropped**: opening vs ending already lives in `other`, and "index" isn't part of guessit's vocabulary.

## Examples

| Filename | `other` | `credits_number` | `version` |
|---|---|---|---|
| `… - OP02 [BD]…` | Opening Credits | `2` | |
| `…_OP4a_…` | Opening Credits | `4a` | |
| `…_ED2v2_Clean_…` | Ending Credits | `2` | `2` |
| `…NCED_EP12…` | Ending Credits, Creditless | | (episode 12) |
| `Code_Geass_Creditless_OP5_…` | Opening Credits, Creditless | `5` | |
| `Ed.S01E01…` | *(not captured)* | | |

## Tests

- New + updated cases in `various.yml` (incl. a negative case asserting the name *"Ed"* is **not** matched).
- Schema regenerated via `scripts/gen_schema.py` (adds `credits_number` + `Creditless`).
- Full suite green: `2283 passed, 4 skipped`; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSN8U8jMGw791gxpVpRh6f