### PR TITLE
feat(episodes): support Chinese season/episode markers 第N季 / 第N集 (#779)

### DIFF
--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -28,6 +28,40 @@ if TYPE_CHECKING:
     from rebulk.match import Matches
 
 
+_CJK_DIGITS = {
+    "零": 0,
+    "一": 1,
+    "二": 2,
+    "两": 2,
+    "三": 3,
+    "四": 4,
+    "五": 5,
+    "六": 6,
+    "七": 7,
+    "八": 8,
+    "九": 9,
+}
+
+# ASCII digits or Han numerals up to 99 (十一 -> 11, 二十三 -> 23, single digit otherwise).
+cjk_number = r"(?:\d{1,4}|[一二两三四五六七八九]?十[一二两三四五六七八九]?|[零一二两三四五六七八九])"
+
+
+def parse_cjk_number(value: str) -> int:
+    """Parse a season/episode number written as ASCII digits or CJK numerals.
+
+    Handles Han numerals up to 99 so Chinese markers such as ``第二季`` (#779)
+    resolve to a numeric value (二 -> 2, 十一 -> 11, 二十三 -> 23).
+    """
+    if value.isdigit():
+        return int(value)
+    if "十" in value:
+        tens, _, ones = value.partition("十")
+        tens_value = _CJK_DIGITS[tens] if tens else 1
+        ones_value = _CJK_DIGITS[ones] if ones else 0
+        return tens_value * 10 + ones_value
+    return _CJK_DIGITS[value]
+
+
 def episodes(config: dict[str, Any]) -> Rebulk:
     """
     Builder for rebulk object.
@@ -190,9 +224,21 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         )
     )
 
-    # CJK (Japanese) episode/season markers (upstream #671, #763).
+    # CJK episode/season markers (Japanese: upstream #671, #763; Chinese: #779).
     # The glyphs never appear in Latin tokens, so no seps-surround validation is needed.
-    rebulk.regex(r"第(?P<episode>\d{1,4})話", tags=["SxxExx"], disabled=is_season_episode_disabled)
+    # Numbers may be ASCII digits or Han numerals (二 -> 2), e.g. 第二季 -> season 2.
+    rebulk.regex(
+        r"第(?P<episode>" + cjk_number + r")[話话集]",
+        tags=["SxxExx"],
+        formatter={"episode": parse_cjk_number},
+        disabled=is_season_episode_disabled,
+    )
+    rebulk.regex(
+        r"第(?P<season>" + cjk_number + r")季",
+        tags=["SxxExx"],
+        formatter={"season": parse_cjk_number},
+        disabled=is_season_episode_disabled,
+    )
     rebulk.regex(
         r"(?:シーズン|シリーズ)(?P<season>\d{1,2})(?!\d)", tags=["SxxExx"], disabled=is_season_episode_disabled
     )

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -4839,6 +4839,32 @@
   season: 2
   type: episode
 
+# Chinese season/episode markers 第N季 / 第N集, ASCII or Han numerals (#779)
+? 庆余年第二季/01.mp4
+: title: 庆余年
+  season: 2
+  episode: 1
+  type: episode
+
+? 庆余年第2季/01.mp4
+: title: 庆余年
+  season: 2
+  episode: 1
+  type: episode
+
+? 庆余年 第二季 第3集.mp4
+: title: 庆余年
+  season: 2
+  episode: 3
+  type: episode
+
+# Han numeral composition: 十一 -> 11, 二十三 -> 23 (#779)
+? 庆余年第十一季 第二十三集.mkv
+: title: 庆余年
+  season: 11
+  episode: 23
+  type: episode
+
 # Unicode x (U+00D7) normalised like x (upstream #790)
 ? La casa del dragón 2×7.mkv
 : title: La casa del dragón


### PR DESCRIPTION
Adds support for Chinese CJK season/episode markers, complementing the existing Japanese markers (`第N話`, `シーズンN`, `N期`).

## Context

Issue #779 reported `庆余年第二季/01.mp4` (*Joy of Life — Season 2*) parsing with no season: `第二季` (= "season 2") was kept inside the title. GuessIt only handled Japanese CJK markers; Chinese ones were unsupported.

## Changes

- New patterns `第N季` (season) and `第N集` (episode) in `episodes.py`.
- Numbers accept ASCII digits **or** Han numerals up to 99, via a new `parse_cjk_number` helper (`二` -> 2, `十一` -> 11, `二十三` -> 23).
- 4 regression entries added to `episodes.yml`.

## Results

```
庆余年第二季/01.mp4        -> title: 庆余年, season: 2, episode: 1
庆余年 第二季 第3集.mp4     -> title: 庆余年, season: 2, episode: 3
庆余年第十一季 第二十三集.mkv -> title: 庆余年, season: 11, episode: 23
```

Japanese markers remain unchanged (non-regression verified). Full suite: 2301 passed, 4 skipped; ruff + mypy --strict clean.

closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)