### PR TITLE
feat: migrate to rebulk 6 and adopt typed Key handles

### DIFF
--- a/guessit/api.py
+++ b/guessit/api.py
@@ -271,7 +271,7 @@ class GuessItApi:
             output_input_string = options.get("output_input_string", False)
             if output_input_string:
                 matches_dict["input_string"] = matches.input_string
-            # rebulk 5 types MatchesDict keys as ``str | None``; every guessit
+            # rebulk 6 types MatchesDict keys as ``str | None``; every guessit
             # property (and ``input_string``) is named, so the keys are always ``str``.
             return cast("dict[str, Any]", matches_dict)
         except Exception as err:

--- a/guessit/api.py
+++ b/guessit/api.py
@@ -10,7 +10,7 @@ import traceback
 from collections import OrderedDict
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from rebulk.introspector import introspect
 
@@ -271,7 +271,9 @@ class GuessItApi:
             output_input_string = options.get("output_input_string", False)
             if output_input_string:
                 matches_dict["input_string"] = matches.input_string
-            return matches_dict
+            # rebulk 5 types MatchesDict keys as ``str | None``; every guessit
+            # property (and ``input_string``) is named, so the keys are always ``str``.
+            return cast("dict[str, Any]", matches_dict)
         except Exception as err:
             raise GuessitException(string, options) from err
 

--- a/guessit/config/__init__.py
+++ b/guessit/config/__init__.py
@@ -58,7 +58,11 @@ def _eval(value: str) -> Any:
     return eval(compiled)
 
 
-def _process_option_executable(value: str, default_module_name: str | None = None) -> Any:
+def _process_option_executable(value: Any, default_module_name: str | None = None) -> Any:
+    if not isinstance(value, str):
+        # Already-resolved callable (e.g. a typed Key converter injected by a rule
+        # module), not an "import:"/"eval:" spec to resolve.
+        return value
     if value.startswith(_import_prefix):
         value = value[len(_import_prefix) :]
         return _import(value, default_module_name)

--- a/guessit/config/__init__.py
+++ b/guessit/config/__init__.py
@@ -58,11 +58,7 @@ def _eval(value: str) -> Any:
     return eval(compiled)
 
 
-def _process_option_executable(value: Any, default_module_name: str | None = None) -> Any:
-    if not isinstance(value, str):
-        # Already-resolved callable (e.g. a typed Key converter injected by a rule
-        # module), not an "import:"/"eval:" spec to resolve.
-        return value
+def _process_option_executable(value: str, default_module_name: str | None = None) -> Any:
     if value.startswith(_import_prefix):
         value = value[len(_import_prefix) :]
         return _import(value, default_module_name)

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -110,7 +110,6 @@
         "_": {
           "regex": ["\\d+-?[kmg]b(ps|its?)", "\\d+\\.\\d+-?[kmg]b(ps|its?)"],
           "conflict_solver": "lambda match, other: match if other.name == 'audio_channels' and 'weak-audio_channels' not in other.tags else other",
-          "formatter": "import:guessit.rules.common.quantity:BitRate.fromstring",
           "tags": ["release-group-prefix"]
         }
       }
@@ -121,7 +120,6 @@
           "regex": "x(\\d+)",
           "private_parent": true,
           "children": true,
-          "formatter": "eval:int",
           "validator": {"__parent__": "import:seps_surround"},
           "validate_all": true,
           "conflict_solver": "lambda match, conflicting: match if conflicting.name in ('video_codec', 'episode') and 'weak-episode' not in conflicting.tags else '__default__'"
@@ -135,7 +133,6 @@
           "cd": "lambda match: 0 < match.value < 100",
           "cd_count": "lambda match: 0 < match.value < 100"
         },
-        "formatter": {"cd": "eval:int", "cd_count": "eval:int"},
         "children": true,
         "private_parent": true,
         "properties": {"cd": [null], "cd_count": [null]}
@@ -146,7 +143,6 @@
           "cd": "lambda match: 0 < match.value < 100",
           "cd_count": "lambda match: 0 < match.value < 100"
         },
-        "formatter": {"cd_count": "eval:int"},
         "children": true,
         "private_parent": true,
         "properties": {"cd": [null], "cd_count": [null]}
@@ -348,7 +344,7 @@
     },
     "film": {
       "film": {
-        "_f": {"regex": "f(\\d{1,2})", "name": "film", "validate_all": true, "validator": {"__parent__": "import:seps_surround"}, "private_parent": true, "children": true, "formatter": "eval:int"}
+        "_f": {"regex": "f(\\d{1,2})", "name": "film", "validate_all": true, "validator": {"__parent__": "import:seps_surround"}, "private_parent": true, "children": true}
       }
     },
     "language": {

--- a/guessit/rules/common/keys.py
+++ b/guessit/rules/common/keys.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Typed keys (rebulk 5) binding match names to value types and formatters.
+Typed keys (rebulk 6) binding match names to value types and formatters.
 
 Single source of truth for the scalar properties whose patterns are built with a
 typed :class:`~rebulk.key.Key`. Each key wires the match ``name``, its Python

--- a/guessit/rules/common/keys.py
+++ b/guessit/rules/common/keys.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+"""
+Typed keys (rebulk 5) binding match names to value types and formatters.
+
+Single source of truth for the scalar properties whose patterns are built with a
+typed :class:`~rebulk.key.Key`. Each key wires the match ``name``, its Python
+value type and the ``(str) -> value`` formatter in one place: passing it via
+``key=`` (Python-built patterns) or as a default formatter to
+:func:`~guessit.config.load_config_patterns` (config-driven patterns) keeps that
+binding here, and enables typed retrieval elsewhere (``matches[KEY]`` ->
+``T | None``, ``matches.all(KEY)`` -> ``list[T]``).
+
+``value_type`` must be scalar; structured/enum properties (``source``, ``other``,
+…) carry no conversion and are intentionally left out.
+"""
+
+from __future__ import annotations
+
+from rebulk import Key
+from rebulk.remodule import re
+
+from .quantity import BitRate, Size
+
+
+def _format_volume(value: str) -> int:
+    """Extract the volume number from a matched ``vol…N`` token."""
+    return int(re.sub(r"\D", "", value))
+
+
+# crc / uuid (raw string values)
+CRC32 = Key("crc32", str)
+UUID = Key("uuid", str)
+
+# integer counters
+BONUS = Key("bonus", int)
+CD = Key("cd", int)
+CD_COUNT = Key("cd_count", int)
+FILM = Key("film", int)
+VOLUME = Key("volume", int, formatter=_format_volume)
+
+# quantities (custom scalar value types)
+SIZE = Key("size", Size, formatter=Size.fromstring)
+#: ``bit_rate`` is an internal match name; ``BitRateTypeRule`` renames it to the
+#: emitted ``audio_bit_rate`` / ``video_bit_rate`` properties.
+BIT_RATE = Key("bit_rate", BitRate, formatter=BitRate.fromstring)

--- a/guessit/rules/common/keys.py
+++ b/guessit/rules/common/keys.py
@@ -38,8 +38,16 @@ CD_COUNT = Key("cd_count", int)
 FILM = Key("film", int)
 VOLUME = Key("volume", int, formatter=_format_volume)
 
+# episode core: declared once on the episodes builder; digit patterns inherit
+# ``int`` per name while roman/CJK patterns keep their own formatter override.
+#: ``count`` is an internal match name, renamed to ``episode_count`` / ``season_count``.
+SEASON = Key("season", int)
+EPISODE = Key("episode", int)
+VERSION = Key("version", int)
+COUNT = Key("count", int)
+
 # quantities (custom scalar value types)
 SIZE = Key("size", Size, formatter=Size.fromstring)
-#: ``bit_rate`` is an internal match name; ``BitRateTypeRule`` renames it to the
-#: emitted ``audio_bit_rate`` / ``video_bit_rate`` properties.
-BIT_RATE = Key("bit_rate", BitRate, formatter=BitRate.fromstring)
+#: Patterns build matches named ``audio_bit_rate``; ``BitRateTypeRule`` renames
+#: some of them to ``video_bit_rate`` afterwards (same value type).
+AUDIO_BIT_RATE = Key("audio_bit_rate", BitRate, formatter=BitRate.fromstring)

--- a/guessit/rules/properties/bit_rate.py
+++ b/guessit/rules/properties/bit_rate.py
@@ -13,7 +13,7 @@ from rebulk.rules import RemoveMatch, RenameMatch, Rule
 
 from ...config import load_config_patterns
 from ..common import dash, seps
-from ..common.keys import BIT_RATE
+from ..common.keys import AUDIO_BIT_RATE
 from ..common.pattern import is_disabled
 from ..common.validators import seps_surround
 
@@ -35,8 +35,9 @@ def bit_rate(config: dict[str, Any]) -> Rebulk:
     )
     rebulk = rebulk.regex_defaults(flags=re.IGNORECASE, abbreviations=[dash])
     rebulk.defaults(name="audio_bit_rate", validator=seps_surround)
+    rebulk.declare_keys(AUDIO_BIT_RATE)
 
-    load_config_patterns(rebulk, config.get("bit_rate"), options={None: {"formatter": BIT_RATE.converter}})
+    load_config_patterns(rebulk, config.get("bit_rate"))
 
     rebulk.rules(BitRateTypeRule)
 

--- a/guessit/rules/properties/bit_rate.py
+++ b/guessit/rules/properties/bit_rate.py
@@ -13,6 +13,7 @@ from rebulk.rules import RemoveMatch, RenameMatch, Rule
 
 from ...config import load_config_patterns
 from ..common import dash, seps
+from ..common.keys import BIT_RATE
 from ..common.pattern import is_disabled
 from ..common.validators import seps_surround
 
@@ -35,7 +36,7 @@ def bit_rate(config: dict[str, Any]) -> Rebulk:
     rebulk = rebulk.regex_defaults(flags=re.IGNORECASE, abbreviations=[dash])
     rebulk.defaults(name="audio_bit_rate", validator=seps_surround)
 
-    load_config_patterns(rebulk, config.get("bit_rate"))
+    load_config_patterns(rebulk, config.get("bit_rate"), options={None: {"formatter": BIT_RATE.converter}})
 
     rebulk.rules(BitRateTypeRule)
 

--- a/guessit/rules/properties/bonus.py
+++ b/guessit/rules/properties/bonus.py
@@ -12,6 +12,7 @@ from rebulk.remodule import re
 
 from ...config import load_config_patterns
 from ..common.formatters import cleanup
+from ..common.keys import BONUS
 from ..common.pattern import is_disabled
 from .title import TitleFromPosition
 
@@ -31,7 +32,7 @@ def bonus(config: dict[str, Any]) -> Rebulk:
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, "bonus"))
     rebulk = rebulk.regex_defaults(name="bonus", flags=re.IGNORECASE)
 
-    load_config_patterns(rebulk, config.get("bonus"))
+    load_config_patterns(rebulk, config.get("bonus"), options={None: {"formatter": BONUS.converter}})
 
     rebulk.rules(BonusTitleRule)
 

--- a/guessit/rules/properties/bonus.py
+++ b/guessit/rules/properties/bonus.py
@@ -31,8 +31,9 @@ def bonus(config: dict[str, Any]) -> Rebulk:
     """
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, "bonus"))
     rebulk = rebulk.regex_defaults(name="bonus", flags=re.IGNORECASE)
+    rebulk.declare_keys(BONUS)
 
-    load_config_patterns(rebulk, config.get("bonus"), options={None: {"formatter": BONUS.converter}})
+    load_config_patterns(rebulk, config.get("bonus"))
 
     rebulk.rules(BonusTitleRule)
 

--- a/guessit/rules/properties/cd.py
+++ b/guessit/rules/properties/cd.py
@@ -27,9 +27,8 @@ def cd(config: dict[str, Any]) -> Rebulk:
     """
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, "cd"))
     rebulk = rebulk.regex_defaults(flags=re.IGNORECASE, abbreviations=[dash])
+    rebulk.declare_keys(CD, CD_COUNT)
 
-    load_config_patterns(
-        rebulk, config, options={None: {"formatter": {"cd": CD.converter, "cd_count": CD_COUNT.converter}}}
-    )
+    load_config_patterns(rebulk, config)
 
     return rebulk

--- a/guessit/rules/properties/cd.py
+++ b/guessit/rules/properties/cd.py
@@ -12,6 +12,7 @@ from rebulk.remodule import re
 
 from ...config import load_config_patterns
 from ..common import dash
+from ..common.keys import CD, CD_COUNT
 from ..common.pattern import is_disabled
 
 
@@ -27,6 +28,8 @@ def cd(config: dict[str, Any]) -> Rebulk:
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, "cd"))
     rebulk = rebulk.regex_defaults(flags=re.IGNORECASE, abbreviations=[dash])
 
-    load_config_patterns(rebulk, config)
+    load_config_patterns(
+        rebulk, config, options={None: {"formatter": {"cd": CD.converter, "cd_count": CD_COUNT.converter}}}
+    )
 
     return rebulk

--- a/guessit/rules/properties/crc.py
+++ b/guessit/rules/properties/crc.py
@@ -7,15 +7,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from rebulk import Key, Rebulk
+from rebulk import Rebulk
 from rebulk.remodule import re
 
+from ..common.keys import CRC32, UUID
 from ..common.pattern import is_disabled
 from ..common.validators import seps_surround
-
-#: Typed keys (rebulk 5) binding each match name to its value type.
-CRC32 = Key("crc32", str)
-UUID = Key("uuid", str)
 
 
 def crc(config: dict[str, Any]) -> Rebulk:

--- a/guessit/rules/properties/crc.py
+++ b/guessit/rules/properties/crc.py
@@ -7,11 +7,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from rebulk import Rebulk
+from rebulk import Key, Rebulk
 from rebulk.remodule import re
 
 from ..common.pattern import is_disabled
 from ..common.validators import seps_surround
+
+#: Typed keys (rebulk 5) binding each match name to its value type.
+CRC32 = Key("crc32", str)
+UUID = Key("uuid", str)
 
 
 def crc(config: dict[str, Any]) -> Rebulk:
@@ -29,13 +33,13 @@ def crc(config: dict[str, Any]) -> Rebulk:
 
     rebulk.regex(
         "(?:[a-fA-F]|[0-9]){8}",
-        name="crc32",
+        key=CRC32,
         conflict_solver=lambda match, other: other if other.name in ["episode", "season"] else "__default__",
     )
 
     rebulk.functional(
         guess_idnumber,
-        name="uuid",
+        key=UUID,
         conflict_solver=lambda match, other: match if other.name in ["episode", "season"] else "__default__",
     )
     return rebulk

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -245,7 +245,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     rebulk.regex(r"(?<!\d)(?P<season>\d{1,2})期", tags=["SxxExx"], disabled=is_season_episode_disabled)
 
     # S01E02, 01x02, S01S02S03
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         tags=["SxxExx"],
         validate_all=True,
         validator={"__parent__": and_(seps_surround, ordering_validator)},
@@ -264,7 +264,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         + r"(?P<episode>\d+)"
     ).repeater("*")
 
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         tags=["SxxExx"],
         validate_all=True,
         validator={"__parent__": and_(seps_surround, ordering_validator)},
@@ -273,7 +273,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         r"(?P<season>\d+)@?" + build_or_pattern(season_ep_markers, name="episodeMarker") + r"@?(?P<episode>\d+)"
     ).repeater("+")
 
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         tags=["SxxExx"],
         validate_all=True,
         validator={"__parent__": and_(seps_surround, ordering_validator)},
@@ -287,7 +287,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         + r"(?P<episode>\d+)"
     ).repeater("*")
 
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         tags=["SxxExx"],
         validate_all=True,
         validator={"__parent__": and_(seps_surround, ordering_validator)},
@@ -319,7 +319,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         conflict_solver=season_episode_conflict_solver,
     )
 
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         validate_all=True,
         conflict_solver=season_episode_conflict_solver,
         formatter={"season": parse_numeral, "count": parse_numeral},
@@ -375,7 +375,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     )
 
     # 12, 13
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         tags=["weak-episode"],
         disabled=lambda context: context.get("type") == "movie" or is_disabled(context, "episode"),
     ).defaults(validator=None, tags=["weak-episode"]).regex(r"(?P<episode>\d{2})").regex(r"v(?P<version>\d+)").repeater(
@@ -383,7 +383,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     ).regex(r"(?P<episodeSeparator>[x-])(?P<episode>\d{2})", abbreviations=None).repeater("*")
 
     # 012, 013
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         tags=["weak-episode"],
         disabled=lambda context: context.get("type") == "movie" or is_disabled(context, "episode"),
     ).defaults(validator=None, tags=["weak-episode"]).regex(r"0(?P<episode>\d{1,2})").regex(
@@ -391,7 +391,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     ).repeater("?").regex(r"(?P<episodeSeparator>[x-])0(?P<episode>\d{1,2})", abbreviations=None).repeater("*")
 
     # 112, 113
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         tags=["weak-episode"],
         name="weak_episode",
         disabled=lambda context: context.get("type") == "movie" or is_disabled(context, "episode"),
@@ -404,7 +404,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     # episode list: that digit is the prefix of a dash-separated release group (e.g. the
     # obfuscation prefix in "x264.1-URANiME-Obfuscated", #627), not a single-digit episode.
     # A range ("1-2", digit-dash-digit) is unaffected.
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         tags=["weak-episode"],
         disabled=lambda context: context.get("type") != "episode" or is_disabled(context, "episode"),
     ).defaults(validator=None, tags=["weak-episode"]).regex(r"(?P<episode>\d)(?!-[a-z])", abbreviations=None).regex(
@@ -412,28 +412,28 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     ).repeater("?").regex(r"(?P<episodeSeparator>[x-])(?P<episode>\d{1,2})", abbreviations=None).repeater("*")
 
     # e112, e113, 1e18, 3e19
-    rebulk.chain(disabled=lambda context: is_disabled(context, "episode")).defaults(validator=None).regex(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(disabled=lambda context: is_disabled(context, "episode")).defaults(validator=None).regex(
         r"(?P<season>\d{1,2})?(?P<episodeMarker>e)(?P<episode>\d{1,4})"
     ).regex(r"v(?P<version>\d+)").repeater("?").regex(
         r"(?P<episodeSeparator>e|x|-)(?P<episode>\d{1,4})", abbreviations=None
     ).repeater("*")
 
     # ep 112, ep113, ep112, ep113
-    rebulk.chain(disabled=lambda context: is_disabled(context, "episode")).defaults(validator=None).regex(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(disabled=lambda context: is_disabled(context, "episode")).defaults(validator=None).regex(
         r"ep-?(?P<episode>\d{1,4})"
     ).regex(r"v(?P<version>\d+)").repeater("?").regex(
         r"(?P<episodeSeparator>ep|e|x|-)(?P<episode>\d{1,4})", abbreviations=None
     ).repeater("*")
 
     # cap 112, cap 112_114
-    rebulk.chain(tags=["see-pattern"], disabled=is_season_episode_disabled).defaults(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(tags=["see-pattern"], disabled=is_season_episode_disabled).defaults(
         validator=None, tags=["see-pattern"]
     ).regex(r"(?P<seasonMarker>cap)-?(?P<season>\d{1,2})(?P<episode>\d{2})").regex(
         r"(?P<episodeSeparator>-)(?P<season>\d{1,2})(?P<episode>\d{2})"
     ).repeater("?")
 
     # 102, 0102
-    rebulk.chain(  # type: ignore[attr-defined]  # rebulk Chain.repeater not in stubs
+    rebulk.chain(
         tags=["weak-episode", "weak-duplicate"],
         name="weak_duplicate",
         conflict_solver=season_episode_conflict_solver,

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -20,6 +20,7 @@ from guessit.rules.common.numeral import numeral, parse_numeral
 from ...reutils import build_or_pattern
 from ..common import alt_dash, dash, seps, seps_no_fs
 from ..common.formatters import strip
+from ..common.keys import COUNT, EPISODE, SEASON, VERSION
 from ..common.pattern import is_disabled
 from ..common.validators import and_, int_coercable, seps_surround
 from .title import TitleFromPosition
@@ -214,9 +215,9 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         .regex_defaults(flags=re.IGNORECASE)
         .string_defaults(ignore_case=True)
         .chain_defaults(chain_breaker=episodes_season_chain_breaker)
+        .declare_keys(SEASON, EPISODE, VERSION, COUNT)
         .defaults(
             private_names=["episodeSeparator", "seasonSeparator", "episodeMarker", "seasonMarker"],
-            formatter={"season": int, "episode": int, "version": int, "count": int},
             children=True,
             private_parent=True,
             conflict_solver=season_episode_conflict_solver,
@@ -450,7 +451,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         r"(?P<episodeSeparator>x|-)(?P<episode>\d{2})", abbreviations=None
     ).repeater("*")
 
-    rebulk.regex(r"v(?P<version>\d+)", formatter=int, disabled=lambda context: is_disabled(context, "version"))
+    rebulk.regex(r"v(?P<version>\d+)", disabled=lambda context: is_disabled(context, "version"))
 
     rebulk.defaults(private_names=["episodeSeparator", "seasonSeparator"])
 
@@ -461,7 +462,6 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         + r"-?(?P<count>\d+)-?"
         + build_or_pattern(episode_words)
         + "?",
-        formatter=int,
         pre_match_processor=match_processors.strip,
         disabled=lambda context: is_disabled(context, "episode"),
     )

--- a/guessit/rules/properties/film.py
+++ b/guessit/rules/properties/film.py
@@ -30,8 +30,9 @@ def film(config: dict[str, Any]) -> Rebulk:
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, "film"))
     rebulk.regex_defaults(flags=re.IGNORECASE, abbreviations=[dash]).string_defaults(ignore_case=True)
     rebulk.defaults(name="film", validator=seps_surround)
+    rebulk.declare_keys(FILM)
 
-    load_config_patterns(rebulk, config.get("film"), options={None: {"formatter": FILM.converter}})
+    load_config_patterns(rebulk, config.get("film"))
 
     rebulk.rules(FilmTitleRule)
 

--- a/guessit/rules/properties/film.py
+++ b/guessit/rules/properties/film.py
@@ -13,6 +13,7 @@ from rebulk.remodule import re
 from ...config import load_config_patterns
 from ..common import dash
 from ..common.formatters import cleanup
+from ..common.keys import FILM
 from ..common.pattern import is_disabled
 from ..common.validators import seps_surround
 
@@ -30,7 +31,7 @@ def film(config: dict[str, Any]) -> Rebulk:
     rebulk.regex_defaults(flags=re.IGNORECASE, abbreviations=[dash]).string_defaults(ignore_case=True)
     rebulk.defaults(name="film", validator=seps_surround)
 
-    load_config_patterns(rebulk, config.get("film"))
+    load_config_patterns(rebulk, config.get("film"), options={None: {"formatter": FILM.converter}})
 
     rebulk.rules(FilmTitleRule)
 

--- a/guessit/rules/properties/size.py
+++ b/guessit/rules/properties/size.py
@@ -7,13 +7,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from rebulk import Rebulk
+from rebulk import Key, Rebulk
 from rebulk.remodule import re
 
 from ..common import dash
 from ..common.pattern import is_disabled
 from ..common.quantity import Size
 from ..common.validators import seps_surround
+
+#: Typed key (rebulk 5) binding the ``size`` match name to its :class:`Size` value.
+SIZE = Key("size", Size, formatter=Size.fromstring)
 
 
 def size(config: dict[str, Any]) -> Rebulk:
@@ -27,7 +30,7 @@ def size(config: dict[str, Any]) -> Rebulk:
     """
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, "size"))
     rebulk.regex_defaults(flags=re.IGNORECASE, abbreviations=[dash])
-    rebulk.defaults(name="size", validator=seps_surround)
-    rebulk.regex(r"\d+-?[mgt]b", r"\d+\.\d+-?[mgt]b", formatter=Size.fromstring, tags=["release-group-prefix"])
+    rebulk.defaults(validator=seps_surround)
+    rebulk.regex(r"\d+-?[mgt]b", r"\d+\.\d+-?[mgt]b", key=SIZE, tags=["release-group-prefix"])
 
     return rebulk

--- a/guessit/rules/properties/size.py
+++ b/guessit/rules/properties/size.py
@@ -7,16 +7,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from rebulk import Key, Rebulk
+from rebulk import Rebulk
 from rebulk.remodule import re
 
 from ..common import dash
+from ..common.keys import SIZE
 from ..common.pattern import is_disabled
-from ..common.quantity import Size
 from ..common.validators import seps_surround
-
-#: Typed key (rebulk 5) binding the ``size`` match name to its :class:`Size` value.
-SIZE = Key("size", Size, formatter=Size.fromstring)
 
 
 def size(config: dict[str, Any]) -> Rebulk:

--- a/guessit/rules/properties/volume.py
+++ b/guessit/rules/properties/volume.py
@@ -8,10 +8,19 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from rebulk import Rebulk
+from rebulk import Key, Rebulk
 
 from ..common.pattern import is_disabled
 from ..common.validators import seps_surround
+
+
+def _format_volume(value: str) -> int:
+    """Extract the volume number from a matched ``vol…N`` token."""
+    return int(re.sub(r"\D", "", value))
+
+
+#: Typed key (rebulk 5) binding the ``volume`` match name to its ``int`` value.
+VOLUME = Key("volume", int, formatter=_format_volume)
 
 
 def volume(config: dict[str, Any]) -> Rebulk:
@@ -32,9 +41,8 @@ def volume(config: dict[str, Any]) -> Rebulk:
     # glued, as in the NAS path "/volume1/") is intentionally NOT matched.
     rebulk.regex(
         r"vol(?:\d{1,3}|(?:ume)?[-. ]\d{1,3})",
-        name="volume",
+        key=VOLUME,
         validator=seps_surround,
-        formatter=lambda value: int(re.sub(r"\D", "", value)),
     )
 
     return rebulk

--- a/guessit/rules/properties/volume.py
+++ b/guessit/rules/properties/volume.py
@@ -8,19 +8,11 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from rebulk import Key, Rebulk
+from rebulk import Rebulk
 
+from ..common.keys import VOLUME
 from ..common.pattern import is_disabled
 from ..common.validators import seps_surround
-
-
-def _format_volume(value: str) -> int:
-    """Extract the volume number from a matched ``vol…N`` token."""
-    return int(re.sub(r"\D", "", value))
-
-
-#: Typed key (rebulk 5) binding the ``volume`` match name to its ``int`` value.
-VOLUME = Key("volume", int, formatter=_format_volume)
 
 
 def volume(config: dict[str, Any]) -> Rebulk:

--- a/guessit/test/conftest.py
+++ b/guessit/test/conftest.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+"""Shared pytest configuration for the guessit test suite."""
+
+import rebulk.debug
+
+# Run the whole corpus with rebulk's declared-key check on (Toilal/rebulk#72):
+# every match named after a declared Key (guessit.rules.common.keys, wired via
+# declare_keys) must hold a value of the key's value_type. This turns the ~2300
+# YAML cases into a contract test for the registry's types — a formatter that
+# stops producing the declared type fails fast here instead of silently.
+rebulk.debug.CHECK_DECLARED_KEYS = True

--- a/guessit/test/test_keys.py
+++ b/guessit/test/test_keys.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Tests for the typed Key registry (guessit.rules.common.keys)."""
+
+from typing import Any
+
+from rebulk import Key
+
+from ..api import guessit
+from ..rules.common import keys as keys_module
+from ..schema import GUESSIT_SCHEMA
+
+#: Registry key names that are internal match names, renamed before output and
+#: therefore absent from GUESSIT_SCHEMA. ``bit_rate`` becomes ``audio_bit_rate`` /
+#: ``video_bit_rate`` (see ``BitRateTypeRule``).
+_INTERNAL_NAMES = {"bit_rate"}
+
+
+def _registry() -> list[Key[Any]]:
+    return [value for value in vars(keys_module).values() if isinstance(value, Key)]
+
+
+def test_registry_keys_are_well_formed() -> None:
+    registry = _registry()
+    assert registry, "the Key registry should not be empty"
+    for key in registry:
+        assert key.name, f"{key!r} has an empty name"
+        assert isinstance(key.value_type, type), f"{key.name} value_type must be a type"
+        assert callable(key.converter), f"{key.name} converter must be callable"
+
+
+def test_registry_key_names_are_unique() -> None:
+    names = [key.name for key in _registry()]
+    assert len(names) == len(set(names)), f"duplicate key names: {names}"
+
+
+def test_emitted_key_names_exist_in_schema() -> None:
+    for key in _registry():
+        if key.name in _INTERNAL_NAMES:
+            continue
+        assert key.name in GUESSIT_SCHEMA, f"key {key.name!r} is not an emitted property"
+
+
+def test_registry_formatter_applies_end_to_end() -> None:
+    # A config-driven property whose formatter now comes from the registry Key
+    # (film -> int via FILM.converter) must still yield the typed value.
+    assert guessit("James_Bond-f21-Casino_Royale.mkv").get("film") == 21

--- a/guessit/test/test_keys.py
+++ b/guessit/test/test_keys.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python
 """Tests for the typed Key registry (guessit.rules.common.keys)."""
 
-from typing import Any
+from typing import Any, TypedDict
 
+import pytest
 from rebulk import Key
 
-from ..api import guessit
+from ..api import default_api, guessit
 from ..rules.common import keys as keys_module
 from ..schema import GUESSIT_SCHEMA
 
-#: Registry key names that are internal match names, renamed before output and
-#: therefore absent from GUESSIT_SCHEMA. ``bit_rate`` becomes ``audio_bit_rate`` /
-#: ``video_bit_rate`` (see ``BitRateTypeRule``).
-_INTERNAL_NAMES = {"bit_rate"}
+#: Registry key names that are internal match names, renamed/aggregated before
+#: output and therefore absent from GUESSIT_SCHEMA. ``count`` becomes
+#: ``episode_count`` / ``season_count`` (see the episode rules).
+_INTERNAL_NAMES = {"count"}
 
 
 def _registry() -> list[Key[Any]]:
@@ -41,6 +42,40 @@ def test_emitted_key_names_exist_in_schema() -> None:
 
 
 def test_registry_formatter_applies_end_to_end() -> None:
-    # A config-driven property whose formatter now comes from the registry Key
-    # (film -> int via FILM.converter) must still yield the typed value.
+    # A config-driven property whose formatter now comes from the declared Key
+    # (film -> int) must still yield the typed value.
     assert guessit("James_Bond-f21-Casino_Royale.mkv").get("film") == 21
+
+
+def test_check_keys_has_no_typo_or_dead_declaration() -> None:
+    # Every key passed to declare_keys must be produced by some pattern, so a
+    # typo'd or stale declaration fails fast here (Toilal/rebulk#73).
+    default_api.configure({})
+    assert default_api.rebulk is not None
+    assert default_api.rebulk.check_keys() == []
+
+
+class _SeasonEpisode(TypedDict, total=False):
+    season: int
+    episode: int
+
+
+class _SeasonAsStr(TypedDict, total=False):
+    season: str
+
+
+def test_to_projection_uses_declared_key_types() -> None:
+    # Typed projection (Toilal/rebulk#71): declared keys carry the value type.
+    default_api.configure({})
+    assert default_api.rebulk is not None
+    matches = default_api.rebulk.matches("Show.S03E07.1080p.mkv", {})
+    assert matches.to(_SeasonEpisode) == {"season": 3, "episode": 7}
+
+
+def test_to_projection_rejects_type_contradicting_declared_key() -> None:
+    # season is declared int; a model typing it str must be rejected (#71).
+    default_api.configure({})
+    assert default_api.rebulk is not None
+    matches = default_api.rebulk.matches("Show.S03E07.mkv", {})
+    with pytest.raises(TypeError):
+        matches.to(_SeasonAsStr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "rebulk>=5,<6",
+    "rebulk>=6,<7",
     "babelfish>=0.6.1",
     "python-dateutil>=2.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "rebulk>=4.2.2,<5",
+    "rebulk>=5,<6",
     "babelfish>=0.6.1",
     "python-dateutil>=2.8.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -543,7 +543,7 @@ test = [
 requires-dist = [
     { name = "babelfish", specifier = ">=0.6.1" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
-    { name = "rebulk", specifier = ">=4.2.2,<5" },
+    { name = "rebulk", specifier = ">=5,<6" },
     { name = "regex", marker = "extra == 'regex'" },
 ]
 provides-extras = ["regex"]
@@ -1508,11 +1508,11 @@ wheels = [
 
 [[package]]
 name = "rebulk"
-version = "4.2.2"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0c/87/e9bcdaab8c72fb81e7db22d3e5990f05c0fc74937195e73f2462e0b6e307/rebulk-4.2.2.tar.gz", hash = "sha256:8b248adc39383c9ec08ee33f4e0ab71b12f6467b845f777bd93cafa7084213cb", size = 53824, upload-time = "2026-06-28T12:33:47.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/f5/09e1932bb59be9c4326d4d4a6e5d29ef960cda5dff7d83b1d44c0519d667/rebulk-5.0.0.tar.gz", hash = "sha256:a5165628bc8f6d5c3d4d36cb2c09249aeebf246ca3fcec53b16f3fb7af8aeba4", size = 55286, upload-time = "2026-06-29T06:47:31.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/b6/8336dbda55af24970948005c3ef096ca32480f995818988cd60d53f0bc97/rebulk-4.2.2-py3-none-any.whl", hash = "sha256:bea17bf13b880033e056ba03f2a1f3f66e68c737bbef2f317d6fe8735f283752", size = 65859, upload-time = "2026-06-28T12:33:46.513Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/02/cd13e91c850741b1d150a53919edd443f6133105dfd2af179c14b49cd55e/rebulk-5.0.0-py3-none-any.whl", hash = "sha256:4123fc0a1795ac1fee3bcee049ad0de4b936f3eef5ed1e0c391c42ff1479c062", size = 67377, upload-time = "2026-06-29T06:47:30.052Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -543,7 +543,7 @@ test = [
 requires-dist = [
     { name = "babelfish", specifier = ">=0.6.1" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
-    { name = "rebulk", specifier = ">=5,<6" },
+    { name = "rebulk", specifier = ">=6,<7" },
     { name = "regex", marker = "extra == 'regex'" },
 ]
 provides-extras = ["regex"]
@@ -1508,11 +1508,11 @@ wheels = [
 
 [[package]]
 name = "rebulk"
-version = "5.0.0"
+version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/f5/09e1932bb59be9c4326d4d4a6e5d29ef960cda5dff7d83b1d44c0519d667/rebulk-5.0.0.tar.gz", hash = "sha256:a5165628bc8f6d5c3d4d36cb2c09249aeebf246ca3fcec53b16f3fb7af8aeba4", size = 55286, upload-time = "2026-06-29T06:47:31.128Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/4e/e6baeddbf737c900a2c0a6335696b7dcabe2d9efa1384e8a5b7071a3a3f8/rebulk-6.0.0.tar.gz", hash = "sha256:30a5c13bb1266da6246e9e60f5695d34a9c5bed7d820f3ef50826693dea879ab", size = 65891, upload-time = "2026-06-29T13:05:38.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/02/cd13e91c850741b1d150a53919edd443f6133105dfd2af179c14b49cd55e/rebulk-5.0.0-py3-none-any.whl", hash = "sha256:4123fc0a1795ac1fee3bcee049ad0de4b936f3eef5ed1e0c391c42ff1479c062", size = 67377, upload-time = "2026-06-29T06:47:30.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/8b/a853a0294dbb0544ea34eb178d07ebc8626560d5d3e824069dc9add4ec2c/rebulk-6.0.0-py3-none-any.whl", hash = "sha256:f93e5ae00c19149c047a7fb0c7c3c380f340da56f05ebfa4989bcecee4999601", size = 78101, upload-time = "2026-06-29T13:05:37.836Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Migrate guessit to **rebulk 6** and adopt its typed `Key` feature end to end: a central registry, config-loader wiring via `declare_keys`, and the declared-key checks run over the whole corpus.

Requires **rebulk >=6** (`6.0.0` ships the `Key` work — `declare_keys`, `key=` union, declared-key checks, typed `to()` — and the private-match fix in the declared-key check).

## rebulk 6 migration
- `rebulk>=4.2.2,<5` → `>=6,<7`, locked from PyPI; drop the 13 obsolete `# type: ignore` (`ChainPart.repeater` now typed); cast `to_dict()`'s `MatchesDict[str | None, …]` to the `dict[str, Any]` guessit guarantees.

## Typed `Key`
- **Registry** `guessit/rules/common/keys.py`: single source of truth (name ↔ value type ↔ formatter).
- **Single-value patterns** (`crc32`, `uuid`, `volume`, `size`): `key=KEY`.
- **`declare_keys`** is the one mechanism for per-name formatter wiring:
  - episodes core declares `season`/`episode`/`version`/`count` once — per-name inheritance (digits → `int`, roman/CJK keep their override), replacing the all-or-nothing `defaults(formatter={…})` and dropping the inline `formatter=int` calls;
  - config-driven `film`/`bonus`/`cd`/`audio_bit_rate` declare their key instead of injecting a formatter through `options={None: {…}}` — so the config loader stays untouched.

## Declared-key checks (run in CI)
- `conftest.py` enables rebulk's `CHECK_DECLARED_KEYS` for the suite → the ~2300 YAML cases assert every declared `Key`'s `value_type` as a contract.
- `test_keys.py`: registry well-formedness, `check_keys()` (no typo'd/dead declaration), and `to()` typed projection (declared types drive the model cross-check).

## Validation (rebulk 6.0.0 from PyPI)
- ✅ `uv run pytest` — **2308 passed, 4 skipped** (declared-key check on)
- ✅ `uv run mypy` — clean · ✅ `uv run ruff check` / `format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)