### PR TITLE
release: guessit 4.0.1 (changelog fixes + clean PyPI rendering)

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -9,6 +9,50 @@ import os
 from hatchling.metadata.plugin.interface import MetadataHookInterface
 
 
+def _balance_code_fences(text: str) -> str:
+    """Make Markdown code fences safe to embed in the PyPI long description.
+
+    Auto-generated changelog entries can carry a closing fence with trailing
+    text on the same line, e.g.::
+
+        ``` ([`abc`](https://.../abc))
+
+    CommonMark does not treat such a line as a closing fence (a closing fence
+    may only be followed by whitespace), so the code block is never terminated
+    and swallows the rest of the document into a single ``<pre>`` block on PyPI.
+
+    Normalise every closing fence onto its own line (moving any trailing text to
+    the next line) and close a fence left open at end of input, so the assembled
+    description always has balanced fences.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    open_fence: str | None = None
+    for line in lines:
+        stripped = line.lstrip()
+        if not stripped.startswith("```"):
+            out.append(line)
+            continue
+        backticks = len(stripped) - len(stripped.lstrip("`"))
+        marker = "`" * backticks
+        rest = stripped[backticks:].strip()
+        if open_fence is None:
+            # Opening fence: an info string (e.g. ```python) is valid, keep it.
+            open_fence = marker
+            out.append(line)
+        else:
+            # Inside a block: this closes it. A closing fence cannot carry an
+            # info string, so emit the fence alone and push any trailing text
+            # (typically the commit link) onto its own line.
+            out.append(marker)
+            if rest:
+                out.append(rest)
+            open_fence = None
+    if open_fence is not None:
+        out.append(open_fence)
+    return "\n".join(out)
+
+
 class CustomMetadataHook(MetadataHookInterface):
     """Assemble the long description from README.md + CHANGELOG.md."""
 
@@ -20,5 +64,5 @@ class CustomMetadataHook(MetadataHookInterface):
 
         metadata["readme"] = {
             "content-type": "text/markdown",
-            "text": readme + "\n\n" + changelog,
+            "text": readme + "\n\n" + _balance_code_fences(changelog),
         }


### PR DESCRIPTION
Cut **guessit 4.0.1**: corrected and readable changelog on the PyPI page.

## What changed since 4.0.0
- `fix(packaging)`: balance code fences in the changelog so the PyPI long description renders correctly (a legacy entry left a code block unterminated, swallowing the whole changelog into one `<pre>`).
- `fix(changelog)`: exclude noise commit types (chore/ci/test/style/docs/refactor/build) from the changelog; reformat the v4.0.0 section.
- Insertion marker `<!-- version list -->` added so future releases populate the changelog automatically.

Verified end-to-end (dry-run on the merged tree): semantic-release computes 4.0.1, `twine check` passes, and PyPI's renderer shows 83 headings / 432-char largest code block (was 10 / 137 KB).

⚠️ Merge with a **merge commit** (not squash).