### PR TITLE
fix(title): keep languages instead of a language-only title

### DIFF
--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -171,6 +171,19 @@ class TitleBaseRule(Rule):
         return cropped_holes
 
     @staticmethod
+    def _hole_has_title_text(hole: Match, ignored_matches: list[Match]) -> bool:
+        """
+        Whether a title hole holds any real title text once the ignored matches
+        (languages/countries) are removed. A hole fully covered by ignored matches
+        is just a language/country enumeration, not a title.
+        """
+        input_string = hole.input_string or ""
+        covered: set[int] = set()
+        for ignored in ignored_matches:
+            covered.update(range(ignored.start, ignored.end))
+        return any(index not in covered and input_string[index] not in seps for index in range(hole.start, hole.end))
+
+    @staticmethod
     def is_ignored(match: Match) -> bool:
         """
         Ignore matches when scanning for title (hole).
@@ -276,6 +289,17 @@ class TitleBaseRule(Rule):
             to_keep: list[Match] = []
 
             ignored_matches = matches.range(hole.start, hole.end, self.is_ignored)
+
+            # A hole made up entirely of languages/countries is not a real title
+            # (e.g. "Ita Eng" between codecs, #751): keep the languages rather than
+            # fabricating a title out of them and deleting them. episode_details
+            # ("Pilot", "Special") are excluded: those legitimately become episode_title.
+            if (
+                ignored_matches
+                and all(ignored.name in ("language", "country") for ignored in ignored_matches)
+                and not self._hole_has_title_text(hole, ignored_matches)
+            ):
+                continue
 
             if ignored_matches:
                 for ignored_match in reversed(ignored_matches):

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -327,6 +327,21 @@
   film_title: James Bond
   film: 17
 
+# #751: with a film_title and no real title after the film number, a language-only
+# hole ("Ita Eng") must stay languages and not be promoted to a bogus title.
+? Fast and Furious F9 2021 BluRay 1080p.H264 Ita Eng AC3 5.1 Sub Ita Eng.mkv
+: film_title: Fast and Furious
+  film: 9
+  year: 2021
+  source: Blu-ray
+  screen_size: 1080p
+  video_codec: H.264
+  language: [Italian, English]
+  subtitle_language: Italian
+  audio_codec: Dolby Digital
+  audio_channels: '5.1'
+  -title: y
+
 
 ? /movies/James_Bond-f21-Casino_Royale.mkv
 : title: Casino Royale


### PR DESCRIPTION
## Problème (#751)

Sur `Fast and Furious F9 2021 BluRay 1080p.H264 Ita Eng AC3 5.1 Sub Ita Eng.mkv`, guessit produisait `title: "Ita Eng"` — une aberration : ce sont des langues.

`F9` est lu comme `film=9` et `Fast and Furious` devient `film_title` (motif `film_title-fNN-title`, cf. `James_Bond-f17-Goldeneye`). La position de titre étant ainsi occupée, `TitleFromPosition` attrapait le trou suivant — l'énumération de langues `Ita Eng` — et **supprimait** les matches de langue pour en forger un titre bidon.

## Correctif

Un trou de titre composé **uniquement** de langues/pays n'est pas un titre : on le saute et on préserve les langues. `episode_details` (« Pilot », « Special ») est exclu car sa promotion en `episode_title` est légitime.

Avant → `title: "Ita Eng"`
Après → `language: [Italian, English]`, `subtitle_language: Italian`, aucun `title`.

## Tests
- Suite complète au vert (2308 passed, 4 skipped), ruff + mypy OK.
- Entrée de régression ajoutée dans `movies.yml`.
- Faux positifs écartés : `The Italian Job`, titres homonymes de pays (`Australia`, `Brazil`…) gardent leur titre.

fixes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)