### PR TITLE
docs(readme): link to the guessit-js TypeScript/WASM port

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ For example, GuessIt can do the following:
 
 More information is available at [guessit-io.github.io/guessit](https://guessit-io.github.io/guessit).
 
+JavaScript / TypeScript port
+----------------------------
+
+Looking for a JavaScript implementation? [guessit-js](https://github.com/opensubtitles/guessit-js) is a third-party TypeScript/WASM port (maintained by [OpenSubtitles](https://www.opensubtitles.org)) that runs in Node, browsers and WASM with no Python required. It is not affiliated with this project.
+
 Support
 -------
 


### PR DESCRIPTION
Ajoute une section dans le README pointant vers [guessit-js](https://github.com/opensubtitles/guessit-js), le port TypeScript/WASM tiers maintenu par OpenSubtitles, pour les utilisateurs cherchant une implémentation JavaScript.

closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)