### PR TITLE
release: v4.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ For example, GuessIt can do the following:
 
 More information is available at [guessit-io.github.io/guessit](https://guessit-io.github.io/guessit).
 
+JavaScript / TypeScript port
+----------------------------
+
+Looking for a JavaScript implementation? [guessit-js](https://github.com/opensubtitles/guessit-js) is a third-party TypeScript/WASM port (maintained by [OpenSubtitles](https://www.opensubtitles.org)) that runs in Node, browsers and WASM with no Python required. It is not affiliated with this project.
+
 Support
 -------
 

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -171,6 +171,19 @@ class TitleBaseRule(Rule):
         return cropped_holes
 
     @staticmethod
+    def _hole_has_title_text(hole: Match, ignored_matches: list[Match]) -> bool:
+        """
+        Whether a title hole holds any real title text once the ignored matches
+        (languages/countries) are removed. A hole fully covered by ignored matches
+        is just a language/country enumeration, not a title.
+        """
+        input_string = hole.input_string or ""
+        covered: set[int] = set()
+        for ignored in ignored_matches:
+            covered.update(range(ignored.start, ignored.end))
+        return any(index not in covered and input_string[index] not in seps for index in range(hole.start, hole.end))
+
+    @staticmethod
     def is_ignored(match: Match) -> bool:
         """
         Ignore matches when scanning for title (hole).
@@ -276,6 +289,17 @@ class TitleBaseRule(Rule):
             to_keep: list[Match] = []
 
             ignored_matches = matches.range(hole.start, hole.end, self.is_ignored)
+
+            # A hole made up entirely of languages/countries is not a real title
+            # (e.g. "Ita Eng" between codecs, #751): keep the languages rather than
+            # fabricating a title out of them and deleting them. episode_details
+            # ("Pilot", "Special") are excluded: those legitimately become episode_title.
+            if (
+                ignored_matches
+                and all(ignored.name in ("language", "country") for ignored in ignored_matches)
+                and not self._hole_has_title_text(hole, ignored_matches)
+            ):
+                continue
 
             if ignored_matches:
                 for ignored_match in reversed(ignored_matches):

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -327,6 +327,21 @@
   film_title: James Bond
   film: 17
 
+# #751: with a film_title and no real title after the film number, a language-only
+# hole ("Ita Eng") must stay languages and not be promoted to a bogus title.
+? Fast and Furious F9 2021 BluRay 1080p.H264 Ita Eng AC3 5.1 Sub Ita Eng.mkv
+: film_title: Fast and Furious
+  film: 9
+  year: 2021
+  source: Blu-ray
+  screen_size: 1080p
+  video_codec: H.264
+  language: [Italian, English]
+  subtitle_language: Italian
+  audio_codec: Dolby Digital
+  audio_channels: '5.1'
+  -title: y
+
 
 ? /movies/James_Bond-f21-Casino_Royale.mkv
 : title: Casino Royale


### PR DESCRIPTION
Release **v4.0.2** (patch).

### Bug fixes
- **title**: keep languages instead of fabricating a language-only title (#870, fixes #751)

### Docs
- link to the guessit-js TypeScript/WASM port in the README (#871, closes #809)

Merge as a **merge commit** (never squash) so semantic-release sees the conventional commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)