### PR TITLE
test: accept guessit date year as a cross-parser year match

### DIFF
--- a/guessit/test/_cross_parser.py
+++ b/guessit/test/_cross_parser.py
@@ -38,6 +38,11 @@ def field_matches(result: dict[str, Any], field: str, expected: Any) -> bool:
     got = result.get(field)
     if field == "title":
         return got is not None and normalize_title(got) == normalize_title(expected)
+    if field == "year" and got is None:
+        # guessit folds a full air date into `date` (no separate `year`); other
+        # parsers only keep the year, so accept the date's year as a match.
+        date = result.get("date")
+        return date is not None and str(getattr(date, "year", None)) == str(expected)
     if field in ("season", "episode") and (isinstance(expected, list) or isinstance(got, list)):
         # compare as sets so a scalar and its single-element list are equal both ways
         got_set = set(got) if isinstance(got, list) else {got}

--- a/guessit/test/cross_parser/baseline.json
+++ b/guessit/test/cross_parser/baseline.json
@@ -275,7 +275,6 @@
     ],
     "WWE Monday Night Raw 3rd Nov 2014 HDTV x264-Sir Paul": [
       "title",
-      "year",
       "type"
     ],
     "Jack.And.The.Cuckoo-Clock.Heart.2013.BRRip XViD": [
@@ -288,7 +287,6 @@
       "source"
     ],
     "WWE Monday Night Raw 2014 11 10 WS PDTV x264-RKOFAN1990 -={SPARR": [
-      "year",
       "source",
       "type"
     ],
@@ -320,7 +318,6 @@
     ],
     "WWE Monday Night Raw 3rd Nov 2014 HDTV x264-Sir Paul": [
       "title",
-      "year",
       "type"
     ],
     "The Shaukeens 2014 Hindi (1CD) DvDScr x264 AAC...Hon3y": [
@@ -330,7 +327,6 @@
       "source"
     ],
     "WWE Monday Night Raw 2014 11 10 WS PDTV x264-RKOFAN1990 -={SPARR": [
-      "year",
       "source",
       "type"
     ]


### PR DESCRIPTION
Follow-up to #873.

Daily shows and dated sports releases (e.g. `WWE Monday Night Raw 3rd Nov 2014`) are parsed by guessit into a full `date` (`2014-11-03`) with **no** separate `year`, whereas the other parsers only record `year=2014`. The cross-parser comparator (`guessit/test/_cross_parser.py`) counted that as a divergence even though guessit is **correct**.

Fix: in `field_matches`, when an expected `year` has no guessit `year`, fall back to the year of guessit's `date`.

Baseline regenerated: **386** known divergences (down from 390 — four spurious `year` mismatches on dated WWE releases dropped). The remaining `year` divergence (`2012 2009 … → year=2012`) is a genuine title-digit issue tracked in #875.

Verified: `uv run pytest -m cross_parser` → 5 passed; mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)