### PR TITLE
fix(film): keep a leading film number in the title

### DIFF
--- a/guessit/rules/properties/film.py
+++ b/guessit/rules/properties/film.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from rebulk import AppendMatch, Rebulk, Rule
+from rebulk import AppendMatch, Rebulk, RemoveMatch, Rule
 from rebulk.remodule import re
 
 from ...config import load_config_patterns
@@ -34,9 +34,34 @@ def film(config: dict[str, Any]) -> Rebulk:
 
     load_config_patterns(rebulk, config.get("film"))
 
-    rebulk.rules(FilmTitleRule)
+    rebulk.rules(LeadingFilmNumberRule, FilmTitleRule)
 
     return rebulk
+
+
+class LeadingFilmNumberRule(Rule):
+    """
+    Discard a film number that leads the file part with nothing before it.
+
+    A collection number only makes sense after a collection title
+    (e.g. ``James Bond f17``). When ``f\\d`` opens the name with no title
+    ahead of it, it belongs to the title itself (e.g. ``F1 The Movie``).
+    """
+
+    consequence = RemoveMatch
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        to_remove: list[Any] = []
+        for film_match in matches.named("film", lambda match: not match.private):
+            filepath = matches.markers.at_match(film_match, lambda marker: marker.name == "path", 0)
+            if not filepath:
+                continue
+            hole = matches.holes(filepath.start, film_match.start + 1, formatter=cleanup, index=0)
+            if not (hole and hole.value):
+                to_remove.append(film_match)
+                if film_match.parent:
+                    to_remove.append(film_match.parent)
+        return to_remove
 
 
 class FilmTitleRule(Rule):

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -327,6 +327,17 @@
   film_title: James Bond
   film: 17
 
+# #879: a leading "f<number>" with no collection title before it is part of
+# the title, not a film number (F1 = the 2025 movie, not "film 1").
+? F1.The.Movie.2025.1080p.AMZN.WEB-DL.DDP5.1.Atmos.H.264-BYNDR.mkv
+: title: F1 The Movie
+  year: 2025
+  -film: 1
+
+? F1.2024.1080p.mkv
+: title: F1
+  -film: 1
+
 # #751: with a film_title and no real title after the film number, a language-only
 # hole ("Ita Eng") must stay languages and not be promoted to a bogus title.
 ? Fast and Furious F9 2021 BluRay 1080p.H264 Ita Eng AC3 5.1 Sub Ita Eng.mkv


### PR DESCRIPTION
## Problem

`F1.The.Movie.2025.1080p.AMZN.WEB-DL.DDP5.1.Atmos.H.264-BYNDR.mkv` was parsed as `film: 1` / `title: "The Movie"` instead of `title: "F1 The Movie"`.

The `film` pattern `f(\d{1,2})` matches the leading `F1` and reads it as a collection number. But a film number only makes sense *after* a collection title (`film_title`) — as in `James Bond f17` or `Fast and Furious F9`. When `f<number>` opens the file part with nothing before it, it is part of the title itself.

## Fix

New rule `LeadingFilmNumberRule` discards a `film` number (and its private parent) when no title hole precedes it in the file part. A film number that follows a collection title is untouched.

| Filename | Before | After |
|---|---|---|
| `F1.The.Movie.2025…` | `film:1` / `title:"The Movie"` | `title:"F1 The Movie"` |
| `F1.2024.1080p` | `film:1` / empty title | `title:"F1"` |
| `James_Bond-f17-Goldeneye` | `film_title:James Bond`, `film:17` | unchanged |
| `Fast and Furious F9 2021` | `film_title:Fast and Furious`, `film:9` | unchanged |

Non-regression entries added to `movies.yml`. Full suite passes (2332 passed), ruff + format + mypy clean.

closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ah1tBeqoVa8sM2CP5ibSJQ