### PR TITLE
feat(title): arbitrate title segments by lexical cohesion (experimental, #884)

### DIFF
--- a/guessit/rules/common/cohesion.py
+++ b/guessit/rules/common/cohesion.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+"""
+Lexical-coherence scoring for title candidates.
+
+A cheap, deterministic proxy for "does this run of words read as a real title phrase"
+(not a grammatical parse): a multilingual function-word backbone plus an alphabetic ratio.
+Used to arbitrate which candidate segment becomes the primary title.
+"""
+
+from __future__ import annotations
+
+from rebulk.remodule import re
+
+# Closed multilingual set of function words (en / fr / es / it / de) that signal a real
+# language phrase rather than a bag of tokens. Romaji particles are intentionally excluded:
+# they collide with release tokens and the arbiter is scoped to Latin-language phrases.
+FUNCTION_WORDS = frozenset(
+    {
+        # en
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "of",
+        "to",
+        "in",
+        "on",
+        "at",
+        "for",
+        "from",
+        "by",
+        "with",
+        "into",
+        "onto",
+        "no",
+        # fr
+        "le",
+        "la",
+        "les",
+        "un",
+        "une",
+        "de",
+        "du",
+        "des",
+        "et",
+        "ou",
+        "dans",
+        "sur",
+        "pour",
+        "par",
+        "avec",
+        # es
+        "el",
+        "los",
+        "las",
+        "y",
+        "en",
+        "con",
+        "por",
+        "para",
+        "del",
+        # it
+        "il",
+        "lo",
+        "gli",
+        "i",
+        "uno",
+        "una",
+        "di",
+        "da",
+        "della",
+        "delle",
+        "dei",
+        # de
+        "der",
+        "die",
+        "das",
+        "und",
+        "oder",
+        "von",
+        "zu",
+        "mit",
+        "im",
+    }
+)
+
+_WORD_SPLIT = re.compile(r"[^0-9a-zà-ÿ]+", re.IGNORECASE)
+
+
+def _words(text: str) -> list[str]:
+    return [word for word in _WORD_SPLIT.split(text.lower()) if word]
+
+
+def title_cohesion(text: str) -> float:
+    """
+    Score how much ``text`` reads as a language phrase (higher = more title-like).
+
+    Combines the fraction of function words (phrase backbone) with the fraction of
+    alphabetic (non-numeric) words. Returns 0.0 for empty / non-word input.
+
+    A language phrase outscores a release-site host:
+
+    >>> title_cohesion("The Wheel of Time") > title_cohesion("www Tamilblasters party")
+    True
+    >>> title_cohesion("")
+    0.0
+    """
+    words = _words(text)
+    if not words:
+        return 0.0
+    function = sum(1 for word in words if word in FUNCTION_WORDS)
+    alphabetic = sum(1 for word in words if not word.isdigit())
+    return function / len(words) + alphabetic / len(words)

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -14,6 +14,7 @@ from rebulk.match import Match
 from rebulk.remodule import re
 
 from ..common import seps, title_seps
+from ..common.cohesion import title_cohesion
 from ..common.comparators import marker_sorted
 from ..common.expected import build_expected_function
 from ..common.formatters import cleanup, reorder_title
@@ -40,6 +41,16 @@ ARTICLES = frozenset({"the", "a", "an", "le", "la", "les", "el", "los", "las", "
 # streaming-service keyword) rather than a real title word — such a token must never be
 # relabelled as the title even when it sits at the title position.
 RELEASE_TAG_MARKERS = ("release-group-prefix", "streaming_service.prefix", "streaming_service.suffix")
+
+# A leading "www"/"ww" host token ("www.TamilBlasters.vip", "www 1TamilMV world") is a
+# release-site prefix, never the title — anchored on the literal prefix so "WW2" is not caught.
+RELEASE_SITE_RE = re.compile(r"^\s*(?:https?://)?w{2,3}[.,\s]", re.IGNORECASE)
+
+
+def _is_release_site(match: Match) -> bool:
+    """Whether a title segment is really a release-site host (www.<host>.<tld>)."""
+    return bool(RELEASE_SITE_RE.match(match.raw or match.value or ""))
+
 
 # Stop-words a title may legitimately end on: refuse cropping a trailing Title-Case
 # language/country that would otherwise leave the title ending on one of these
@@ -361,10 +372,31 @@ class TitleBaseRule(Rule):
                         else:
                             title_match.name = self.alternative_match_name
 
+                    titles = self._arbitrate_title_segments(titles)
                 else:
                     titles = [hole]
                 return titles, to_remove
         return None
+
+    def _arbitrate_title_segments(self, titles: list[Match]) -> list[Match]:
+        """
+        Choose the primary title among the split segments by lexical coherence.
+
+        A leading release-site host (``www.<host>.<tld>``) is dropped so the language-like
+        segment becomes the title instead of the site name (#884). Only triggers when a
+        site segment sits next to a real one; legitimate title / alternative_title splits
+        (no site segment) are left untouched.
+        """
+        if len(titles) < 2:
+            return titles
+        kept = [segment for segment in titles if not _is_release_site(segment)]
+        if not kept or len(kept) == len(titles):
+            return titles
+        primary = max(kept, key=lambda segment: title_cohesion(str(segment.value or "")))
+        for segment in kept:
+            segment.name = self.alternative_match_name
+        primary.name = self.match_name
+        return sorted(kept, key=lambda segment: segment.start)
 
     def _serie_name_filepart(self, matches: Matches, fileparts: list[Match]) -> Match | None:
         # Try to get show title from subdirectory of a season only directory (Show Name/Season 1/episode_title.avi)

--- a/guessit/test/cross_parser/baseline.json
+++ b/guessit/test/cross_parser/baseline.json
@@ -375,9 +375,6 @@
     "[www.1TamilMV.pics]_The.Great.Indian.Suicide.2023.Tamil.TRUE.WEB-DL.4K.SDR.HEVC.(DD+5.1.384Kbps.&.AAC).3.2GB.ESub.mkv": [
       "audio_codec"
     ],
-    "www.5MovieRulz.show - Khel Khel Mein (2024) 1080p Hindi DVDScr - x264 - AAC - 2.3GB.mkv": [
-      "title"
-    ],
     "超能警探.Memorist.S01E01.2160p.WEB-DL.H265.AAC-FLTTH.mkv": [
       "title"
     ],
@@ -403,12 +400,6 @@
     ],
     "Venom (2018) HD-TS 720p Hindi Dubbed (Clean Audio) x264": [
       "source"
-    ],
-    "www.Tamilblasters.party - The Wheel of Time (2021) Season 01 EP(01-08) [720p HQ HDRip - [Tam + Tel + Hin] - DDP5.1 - x264 - 2.7GB - ESubs]": [
-      "title"
-    ],
-    "www.TamilBlasters.vip - Shang-Chi (2021) [720p BDRip - [Tamil + Telugu + Hindi + Eng] - x264 - DDP5.1 (192 Kbps) - 1.4GB - ESubs].mkv": [
-      "title"
     ],
     "Game of Thrones 1ª a 8ª Temporada Completa [720p-1080p] [BluRay] [DUAL]": [
       "title",
@@ -469,11 +460,7 @@
       "title"
     ],
     "www 1TamilBlasters tel - Migration (2023) [English - 720p HQ HDRip - x264 - [DD5 1  (192Kbps) + AAC] - 850MB - ESub] mkv": [
-      "title",
       "audio_codec"
-    ],
-    "www TamilBlasters tel - Sonic the Hedgehog 2 (2022) English 720p HDRip x264 AAC 800MB ESubs mkv": [
-      "title"
     ],
     "Mission Impossible Dead Reckoning Part One 2023 1080p BluRay DDP 7 1 x265-EDGE2020 mkv": [
       "title"
@@ -517,19 +504,10 @@
     "GTO (Great Teacher Onizuka) (Ep. 1-43) Sub 480p lakshay": [
       "title"
     ],
-    "www.1TamilMV.world - Ayalaan (2024) Tamil PreDVD - 1080p - x264 - HQ Clean Aud - 2.5GB.mkv": [
-      "title"
-    ],
     "[www.arabp2p.net]_-_تركي مترجم ومدبلج Last.Call.for.Istanbul.2023.1080p.NF.WEB-DL.DDP5.1.H.264.MKV.torrent": [
       "title"
     ],
-    "www,1TamilMV.phd - The Great Indian Suicide (2023) Tamil TRUE WEB-DL - 4K SDR - HEVC - (DD+5.1 - 384Kbps & AAC) - 3.2GB - ESub.mkv": [
-      "title"
-    ],
     "ww.Tamilblasters.sbs - 8 Bit Christmas (2021) HQ HDRip - x264 - Telugu (Fan Dub) - 400MB].mkv": [
-      "title"
-    ],
-    "www.1TamilMV.pics - 777 Charlie (2022) Tamil HDRip - 720p - x264 - HQ Clean Aud - 1.4GB.mkv": [
       "title"
     ],
     "UFC.247.PPV.Jones.vs.Reyes.HDTV.x264-PUNCH[TGx]": [

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -2054,3 +2054,25 @@
   audio_codec: Dolby Digital
   release_group: Hive-CM8
   type: movie
+
+# #884: a leading release-site host (www.<host>.<tld>) is not the title — the
+# language-like segment after it becomes the title (cohesion arbiter in the
+# title/alternative_title classification).
+? www.Tamilblasters.party - The Wheel of Time (2021) 720p x264
+: title: The Wheel of Time
+  year: 2021
+  screen_size: 720p
+  video_codec: H.264
+  -alternative_title: www Tamilblasters party
+
+? www.5MovieRulz.show - Khel Khel Mein (2024) 1080p x264
+: title: Khel Khel Mein
+  year: 2024
+  screen_size: 1080p
+  video_codec: H.264
+
+? www.TamilBlasters - Titanic (1997) 720p x264
+: title: Titanic
+  year: 1997
+  screen_size: 720p
+  video_codec: H.264


### PR DESCRIPTION
## What

Experimental first cut of the **language-cohesion arbiter** from #884.

Title selection is currently **positional**: `check_titles_in_filepart` splits the title hole on
`title_seps`, makes `titles[0]` the `title` and the rest `alternative_title` — regardless of
whether the leading segment reads as language. So a leading release-site host
(`www.<host>.<tld>`) is picked as the title while the real title sits in `alternative_title`:

```
www.Tamilblasters.party - The Wheel of Time (2021) …
  before →  title="www Tamilblasters party", alternative_title="The Wheel of Time"
  after  →  title="The Wheel of Time"
```

## How

Per @Toilal's steer, the fix lives **inside the title/alternative_title classification**, not as
a post-hoc swap:

- New dependency-free `guessit/rules/common/cohesion.py` — `title_cohesion(text)`, a cheap
  deterministic proxy for "reads as a language phrase" (multilingual function-word backbone +
  alphabetic ratio). Not a grammatical parse; assumed as a lexical proxy so it stays deterministic
  and dependency-free.
- `TitleBaseRule._arbitrate_title_segments` — after the split, drop a release-site host segment
  and promote the **most cohesive** remaining segment to the primary title. It only triggers when
  a site segment sits next to a real one, so legitimate title/alternative_title splits
  (dual titles, subtitles) are left untouched.

Release-site detection is anchored on the literal `www`/`ww` prefix (`RELEASE_SITE_RE`), so `WW2`
is not caught.

## Scope (deliberately narrow — experimental)

This lands only the **URL-prefix** class (~cleanest, lowest-risk: the real title is already
extracted as `alternative_title`, so it is pure re-ranking). The other #884 classes
(trailing release-tag words like `Naruto Collection`; foreign-script prefixes like
`超能警探 Memorist`) are **not** in this PR — they need companion work and carry more risk.

**Explicit non-goal:** this does not merge a title with its subtitle. guessit already decomposes
`Star Wars` / `L'Empire contre-attaque`, `Tower of Druaga` / `Sword of Uruk` sensibly into
`title` + `alternative_title`/`episode_title`; the arbiter must not reverse those, and does not.

## Tests

- 3 new `movies.yml` entries (www prefix → language-like title).
- Doctests on `title_cohesion`.
- Cross-parser baseline regenerated (`--baseline-only`): **7 title divergences removed, 0 new**.
- Full suite green (`2335 passed`), ruff + mypy clean.

Refs #884
