### PR TITLE
docs(claude): require tokens and word lists to live in configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,11 @@ The core parsing is built on **Rebulk**, a declarative pattern matching library.
 - Default config: `guessit/config/options.json`
 - Users can customize via `--config` CLI flag or programmatic `options` dict
 - Options are merged: default → user config → programmatic options
+- **All tokens and word lists must live in the configuration** (`options.json`, under
+  `advanced_config.<property>`), never hard-coded in a rule module. A rule reads its lists from
+  the `config` dict its builder receives; this keeps every vocabulary user-overridable. When
+  adding a feature that needs keywords/stop-words/function-words, add them to `advanced_config`
+  and thread them through the property builder — do not inline a `frozenset`/list literal.
 
 ### Tests
 


### PR DESCRIPTION
Records the project rule that every vocabulary (keywords, stop-words, function-words, TLDs, …) must live in `options.json` under `advanced_config.<property>` and be threaded through the property builder — never hard-coded as a literal in a rule module — so all vocabularies stay user-overridable.

Small doc-only change, split out of the TLD work (#888) to keep that PR strictly about the data refresh.