### PR TITLE
feat(title): split a leading original-language script prefix into alternative_title (closes #890)

### DIFF
--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -41,6 +41,14 @@ ARTICLES = frozenset({"the", "a", "an", "le", "la", "les", "el", "los", "las", "
 # relabelled as the title even when it sits at the title position.
 RELEASE_TAG_MARKERS = ("release-group-prefix", "streaming_service.prefix", "streaming_service.suffix")
 
+# Non-Latin scripts used for original-language titles glued in front of a romanized title
+# (CJK, kana, hangul, Cyrillic, Greek, Arabic, Hebrew, Thai, fullwidth forms). Latin-1 accented
+# letters (à, ñ, …) are deliberately excluded — they are Latin-script title characters.
+NON_LATIN_SCRIPT_RE = re.compile(
+    r"[Ͱ-ϿЀ-ӿ֐-׿؀-ۿ฀-๿"
+    r"　-〿぀-ヿ㐀-䶿一-鿿가-힯＀-￯]"
+)
+
 # Stop-words a title may legitimately end on: refuse cropping a trailing Title-Case
 # language/country that would otherwise leave the title ending on one of these
 # ("It Ends With Us" #789, "The Last of Us" #739, "Oshi no Ko" #745). An uppercase tag
@@ -92,6 +100,7 @@ def title(config: dict[str, Any]) -> Rebulk:
         ExtendLoneArticleTitle,
         PropertyAtTitlePositionAsTitle,
         KeepTrailingStopWordTitle,
+        SplitOriginalScriptTitle,
     )
 
     expected_title = build_expected_function("expected_title")
@@ -741,3 +750,61 @@ class KeepTrailingStopWordTitle(Rule):
             title_match.end = trailing.end
             title_match.value = cleanup(input_string[title_match.start : title_match.end])
             matches.append(title_match)
+
+
+class SplitOriginalScriptTitle(Rule):
+    """
+    A title glued as "<original-language title> <romanized title>" — a leading non-Latin script
+    run in front of a Latin run — yields the Latin part as the title and the original-language run
+    as ``alternative_title`` (#890): "超能警探 Memorist" -> title "Memorist", alternative_title
+    "超能警探".
+
+    Only a *leading* non-Latin run is split. An all-non-Latin title is kept as the title, and dual
+    titles already separated on "/" are untouched (each side is its own segment).
+    """
+
+    priority = POST_PROCESS
+    consequence = [RemoveMatch, AppendMatch]
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        input_string = matches.input_string or ""
+        to_remove: list[Match] = []
+        to_append: list[Match] = []
+        for title_match in matches.named("title"):
+            if "expected" in title_match.tags:
+                continue  # a user-forced expected_title is verbatim, never split
+            raw = input_string[title_match.start : title_match.end]
+            # The Latin part must start a word (preceded by a separator or the string start), so a
+            # stray Latin-homoglyph letter inside a Cyrillic word is not treated as a split point.
+            latin = re.search(rf"(?:^|[{re.escape(seps)}])([A-Za-z])", raw)
+            if not latin:
+                continue  # no romanized run starting a word: keep it as the title
+            latin_offset = latin.start(1)
+            prefix = raw[:latin_offset]
+            if not NON_LATIN_SCRIPT_RE.search(prefix):
+                continue  # numeric / Latin lead: nothing to strip
+            prefix_end = title_match.start + len(prefix.rstrip(seps))
+            latin_start = title_match.start + latin_offset
+            if prefix_end <= title_match.start:
+                continue
+            to_remove.append(title_match)
+            to_append.append(
+                Match(
+                    title_match.start,
+                    prefix_end,
+                    name="alternative_title",
+                    value=cleanup(input_string[title_match.start : prefix_end]),
+                    input_string=input_string,
+                )
+            )
+            to_append.append(
+                Match(
+                    latin_start,
+                    title_match.end,
+                    name="title",
+                    tags=["title"],
+                    value=cleanup(input_string[latin_start : title_match.end]),
+                    input_string=input_string,
+                )
+            )
+        return to_remove, to_append

--- a/guessit/test/cross_parser/baseline.json
+++ b/guessit/test/cross_parser/baseline.json
@@ -375,9 +375,6 @@
     "[www.1TamilMV.pics]_The.Great.Indian.Suicide.2023.Tamil.TRUE.WEB-DL.4K.SDR.HEVC.(DD+5.1.384Kbps.&.AAC).3.2GB.ESub.mkv": [
       "audio_codec"
     ],
-    "超能警探.Memorist.S01E01.2160p.WEB-DL.H265.AAC-FLTTH.mkv": [
-      "title"
-    ],
     "{WWW.BLUDV.TV} Love, Death & Robots - 1ª Temporada Completa 2019 (1080p) Acesse o ORIGINAL WWW.BLUDV.TV": [
       "year"
     ],
@@ -412,7 +409,6 @@
       "title"
     ],
     "抓娃娃 Successor.2024.TC1080P.国语中字": [
-      "title",
       "screen_size",
       "source"
     ],
@@ -481,9 +477,6 @@
     "【喵萌奶茶屋】★01月新番★[別對映像研出手！/映像研には手を出すな！/Eizouken ni wa Te wo Dasu na!][01][1080p][繁體]": [
       "title"
     ],
-    "[Seed-Raws] 劇場版 ペンギン・ハイウェイ Penguin Highway The Movie (BD 1280x720 AVC AACx4 [5.1+2.0+2.0+2.0]).mp4": [
-      "title"
-    ],
     "[SweetSub][Mutafukaz / MFKZ][Movie][BDRip][1080P][AVC 8bit][简体内嵌]": [
       "title"
     ],
@@ -506,9 +499,6 @@
       "title"
     ],
     "GTO (Great Teacher Onizuka) (Ep. 1-43) Sub 480p lakshay": [
-      "title"
-    ],
-    "[www.arabp2p.net]_-_تركي مترجم ومدبلج Last.Call.for.Istanbul.2023.1080p.NF.WEB-DL.DDP5.1.H.264.MKV.torrent": [
       "title"
     ],
     "www,1TamilMV.phd - The Great Indian Suicide (2023) Tamil TRUE WEB-DL - 4K SDR - HEVC - (DD+5.1 - 384Kbps & AAC) - 3.2GB - ESub.mkv": [

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5244,3 +5244,15 @@
 
 ? Apollo 18 Temporada 2
 : season: 2
+
+# #890: a leading original-language (non-Latin) title glued before the romanized title is
+# split — the Latin part is the title, the original run becomes alternative_title.
+? 超能警探.Memorist.S01E01.2160p.WEB-DL.H265.AAC-FLTTH.mkv
+: title: Memorist
+  alternative_title: 超能警探
+  season: 1
+  episode: 1
+  screen_size: 2160p
+  source: Web
+  video_codec: H.265
+  release_group: FLTTH

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -2085,3 +2085,11 @@
   screen_size: 720p
   video_codec: H.264
   website: www.1TamilMV.pics
+
+# #890: leading original-language (non-Latin) title prefix split off into alternative_title.
+? 劇場版 ペンギン・ハイウェイ Penguin Highway The Movie (BD 1280x720 AVC).mp4
+: title: Penguin Highway The Movie
+  alternative_title: 劇場版 ペンギン・ハイウェイ
+  source: Blu-ray
+  screen_size: 720p
+  video_codec: H.264


### PR DESCRIPTION
## What

Closes #890.

When a release glues the **original-language title** (a leading non-Latin script run: CJK, kana,
hangul, Cyrillic, Greek, Arabic, …) in front of its romanized title, guessit kept the whole thing
as the `title`. Now the Latin part is the `title` and the original-language run becomes
`alternative_title`:

```
超能警探.Memorist.S01E01…                          → title "Memorist",  alternative_title "超能警探"
劇場版 ペンギン・ハイウェイ Penguin Highway The Movie …  → title "Penguin Highway The Movie",
                                                       alternative_title "劇場版 ペンギン・ハイウェイ"
```

## How

A `SplitOriginalScriptTitle` rule (POST_PROCESS) on the finalized `title`: if the title starts
with a non-Latin script run (`NON_LATIN_SCRIPT_RE`) followed by a Latin word, crop the title to the
Latin part and emit the original run as `alternative_title`. Structural (Unicode script), no word
lists.

## Guards (all tested)

- **Word-boundary only.** The Latin part must start a word (preceded by a separator/start), so a
  stray Latin homoglyph inside a Cyrillic word is *not* a split point — `Кнiганошы` (a single word
  with a Latin `i`) is kept intact.
- **All-non-Latin titles are kept** as the title (no empty result).
- **Dual titles on `/` are untouched** — each language is already its own segment
  (`… / The Lord of the Rings` stays `The Lord of the Rings`).
- **Latin-1 accented leads are not stripped** (`Ñoño`, `Amélie`) — accented Latin is excluded from
  `NON_LATIN_SCRIPT_RE`.

## Tests

- New `episodes.yml` (`超能警探 Memorist`) and `movies.yml` (`劇場版 … Penguin Highway The Movie`)
  entries, asserting both `title` and `alternative_title`.
- Cross-parser baseline regenerated: **10 title divergences removed, 0 added**.
- Full suite green (`2341 passed`), ruff + mypy clean.
