### PR TITLE
fix(title): reclaim a title-word property value from the title zone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,12 @@ The core parsing is built on **Rebulk**, a declarative pattern matching library.
   the `config` dict its builder receives; this keeps every vocabulary user-overridable. When
   adding a feature that needs keywords/stop-words/function-words, add them to `advanced_config`
   and thread them through the property builder — do not inline a `frozenset`/list literal.
+- **Do not base rules on letter case.** Guessit is case-insensitive by design (patterns match
+  regardless of case), so a rule must not use casing as a discriminator (`re.match(r"^[A-Z]...")`,
+  `.isupper()`, etc.). Real release names come in Title-Case, lowercase and UPPERCASE alike;
+  keying on case makes a rule silently miss the other spellings. Prefer a structural signal
+  (position relative to an anchor, separators, neighbouring matches, a config tag). Rare, clearly
+  justified exceptions may exist, but the default is case-agnostic.
 
 ### Tests
 

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -64,7 +64,7 @@
         "DTS-HD": {"regex":  ["DTS-?HD", "DTS(?=-?MA)"], "conflict_solver": "lambda match, other: other if other.name == 'audio_codec' else '__default__'"},
         "DTS:X": {"string": ["DTS:X", "DTS-X", "DTSX"] },
         "Dolby TrueHD": {"regex": ["True-?HD"] },
-        "Opus": "Opus",
+        "Opus": {"string": "Opus", "tags": "title-word"},
         "Vorbis": "Vorbis",
         "PCM": "PCM",
         "LPCM": "LPCM"

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -95,6 +95,7 @@ def title(config: dict[str, Any]) -> Rebulk:
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, "title"))
     rebulk.rules(
         CountryAtTitlePosition,
+        TitleWordAtTitlePosition,
         TitleFromPosition,
         PreferTitleWithYear,
         ExtendLoneArticleTitle,
@@ -576,6 +577,45 @@ class CountryAtTitlePosition(Rule):
             ):
                 continue
             if not all(ch in seps for ch in input_string[candidate.end : year.start]):
+                continue
+            to_remove.append(candidate)
+        return to_remove
+
+
+class TitleWordAtTitlePosition(Rule):
+    """
+    A property value whose spelling is also a plain title word (tagged ``title-word`` in the
+    vocabulary, e.g. audio_codec "Opus") is really part of the title when it sits in the title
+    zone -- before the first year/season/episode/date anchor of the file part. Removing the
+    property match reopens the title hole so the normal title logic keeps the word, whether it
+    leads, ends or sits in the middle of the title: ``Opus.2025...`` -> "Opus",
+    ``Foo.Opus.2025...`` -> "Foo Opus", ``Foo.Opus.Bar.2025...`` -> "Foo Opus Bar".
+
+    Property-agnostic: any property can opt a value in by tagging it ``title-word``. The anchor
+    is load-bearing (not the casing): a real codec/tag always sits *after* the year/episode
+    marker, so a ``title-word`` before the anchor cannot be the property regardless of case
+    ("opus", "Opus" or "OPUS" all read as the title here). A spelling that appears after the
+    anchor, among the other tags, stays the property.
+    """
+
+    priority = 64
+    consequence = RemoveMatch
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        to_remove: list[Match] = []
+        for candidate in matches.tagged("title-word"):
+            if candidate.private:
+                continue
+            filepart = matches.markers.at_match(candidate, lambda marker: marker.name == "path", 0)
+            if not filepart:
+                continue
+            anchor = matches.range(
+                filepart.start,
+                filepart.end,
+                lambda m: not m.private and m.name in ("year", "season", "episode", "date"),
+                0,
+            )
+            if not anchor or candidate.start >= anchor.start:
                 continue
             to_remove.append(candidate)
         return to_remove

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -2093,3 +2093,46 @@
   source: Blu-ray
   screen_size: 720p
   video_codec: H.264
+
+# #885: a property value that is also a plain title word (tagged title-word, e.g. audio_codec
+# "Opus") sitting in the title zone -- before the year/season/episode anchor -- is title text,
+# not a codec. Case-insensitive and works at the start, end or middle of the title.
+? Opus.2025.Hybrid.2160p.WEB-DL.DV.HDR.DDP5.1.Atmos.H265-AOC.mkv
+: title: Opus
+  year: 2025
+  audio_codec:
+    - Dolby Digital Plus
+    - Dolby Atmos
+  -audio_codec: Opus
+
+? Something.Opus.2025.1080p.WEB-DL.DDP5.1-AOC.mkv
+: title: Something Opus
+  year: 2025
+  -audio_codec: Opus
+
+# Lowercase (scene style): title-word is still reclaimed at the start, end and middle.
+? opus.2025.1080p.web-dl.ddp5.1.atmos.h265-aoc.mkv
+: title: opus
+  year: 2025
+  -audio_codec: Opus
+
+? something.opus.2025.1080p.web-dl.ddp5.1-aoc.mkv
+: title: something opus
+  year: 2025
+  -audio_codec: Opus
+
+? foo.opus.bar.2025.1080p.web-dl.ddp5.1-aoc.mkv
+: title: foo opus bar
+  year: 2025
+  -audio_codec: Opus
+
+# The codec proper stays a codec: "OPUS"/"Opus" that lives in the technical tag block
+# (after the anchor / among the other tags) is untouched, whatever its case.
+? How To Steal A Dog.2014.BluRay.1080p.12bit.HEVC.OPUS 5.1-Hn1Dr2.mkv
+: title: How To Steal A Dog
+  year: 2014
+  audio_codec: Opus
+
+? Alien.Director.Cut.Ita.Eng.VP9.Opus.AlphaBot.webm
+: title: Alien
+  audio_codec: Opus


### PR DESCRIPTION
## Problem (#885)

A property value whose spelling is also a plain title word — the audio_codec **Opus** — was consumed as the property even when it sat at the title position, leaving an empty/truncated title:

```
$ guessit Opus.2025.Hybrid.2160p.WEB-DL.DV.HDR.DDP5.1.Atmos.H265-AOC.mkv
  audio_codec: [Opus, Dolby Digital Plus, Dolby Atmos]
  title: (none)          # "Opus" is the 2025 movie, not the codec
```

Same class as #879 (`F1` eaten by `film`).

## Fix

A property-agnostic **`title-word`** config tag plus a `TitleWordAtTitlePosition` rule (`title.py`, priority 64, `RemoveMatch`, registered before `TitleFromPosition`). A tagged value sitting **before the first year/season/episode/date anchor** of its file part is title text, not the property. Removing the match reopens the title hole, so the word is kept at the **start, middle or end** of the title.

The **anchor is the discriminator** (a real codec/tag always sits *after* the year/episode marker), so the rule is **case-insensitive** — `opus` / `Opus` / `OPUS` all read as the title. A value that appears after the anchor, among the technical tags, stays the property.

```
Opus.2025.…DDP5.1.Atmos…         -> title: Opus,          audio_codec: [DDP+, Atmos]
Something.Opus.2025.…            -> title: Something Opus
foo.opus.bar.2025.…              -> title: foo opus bar
…HEVC.OPUS 5.1-Hn1Dr2.mkv        -> title: …,             audio_codec: Opus   (unchanged)
Alien.…VP9.Opus.AlphaBot.webm    -> title: Alien,         audio_codec: Opus   (unchanged)
```

### Scope

Only `audio_codec` "Opus" is tagged. The before-anchor heuristic is only safe for tokens that conventionally follow the year (audio/video/source); release descriptors (`Extended`, `Proper`, editions…) legitimately precede the year and are intentionally **not** tagged.

### Also

Documents in `CLAUDE.md` that rules must not key on letter case (guessit is case-insensitive by design; the `Us`/`US` country rules remain the documented exception).

## Tests

Non-regression entries added to `movies.yml` (start/middle/end, lower/Title/UPPER case, plus the two "stays a codec" cases). Full suite green (`2346 passed`), ruff + mypy clean.

closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)