### PR TITLE
refactor(config): externalize title/other word lists into advanced_config

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -487,6 +487,16 @@
         "true"
       ]
     },
+    "title": {
+      "articles": [
+        "the", "a", "an", "le", "la", "les", "el", "los", "las", "il", "lo", "l"
+      ],
+      "title_stop_words": [
+        "the", "a", "an", "and", "or", "of", "to", "in", "on", "at", "for",
+        "from", "by", "with", "into", "onto", "no", "le", "la", "les", "de",
+        "du", "des", "el"
+      ]
+    },
     "other": {
       "other": {
         "Audio Fixed": {"regex": ["Audio-?Fix", "Audio-?Fixed"]},
@@ -579,6 +589,19 @@
         "Obfuscated": {"string": ["Obfuscated", "Scrambled"], "tags": ["at-end", "not-a-release-group"]},
         "Repost": {"string": ["xpost", "postbot", "asrequested"], "tags": "not-a-release-group"},
         "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "season_words": ["seasons?", "series?"], "complete_article_words": ["The"]}
+      },
+      "art": {
+        "poster": "Poster",
+        "fanart": "Fanart",
+        "banner": "Banner",
+        "thumb": "Thumbnail",
+        "thumbnail": "Thumbnail",
+        "landscape": "Landscape",
+        "cover": "Cover",
+        "clearart": "Clear Art",
+        "clearlogo": "Clear Logo",
+        "logo": "Logo",
+        "discart": "Disc Art"
       }
     },
     "part": {

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -41,6 +41,8 @@ def other(config: dict[str, Any]) -> Rebulk:
 
     opening_ending_credits(rebulk)
 
+    art_keywords = config.get("art", {})
+
     rebulk.rules(
         RenameAnotherToOther,
         AppendCreditless,
@@ -55,7 +57,7 @@ def other(config: dict[str, Any]) -> Rebulk:
         ValidateAtEnd,
         ValidateReal,
         ValidateStereoVRContext,
-        ImageArtKeywordToOther,
+        ImageArtKeywordToOther(art_keywords),
         ProperCountRule,
     )
 
@@ -138,22 +140,6 @@ def opening_ending_credits(rebulk: Rebulk) -> None:
     # Bare uppercase tokens. OPED is the combined opening+ending sequence (not creditless).
     add(r"OPED|OP", "Opening Credits", ignore_case=False)
     add(r"ED", "Ending Credits", ignore_case=False)
-
-
-#: Artwork file-name keywords mapped to their canonical ``other`` value.
-ART_KEYWORDS = {
-    "poster": "Poster",
-    "fanart": "Fanart",
-    "banner": "Banner",
-    "thumb": "Thumbnail",
-    "thumbnail": "Thumbnail",
-    "landscape": "Landscape",
-    "cover": "Cover",
-    "clearart": "Clear Art",
-    "clearlogo": "Clear Logo",
-    "logo": "Logo",
-    "discart": "Disc Art",
-}
 
 
 def complete_words(rebulk: Rebulk, season_words: Iterable[str], complete_article_words: Iterable[str]) -> None:
@@ -251,7 +237,12 @@ class ImageArtKeywordToOther(Rule):
     priority = POST_PROCESS
     consequence = [RemoveMatch, AppendMatch]
 
-    properties = {"other": list(dict.fromkeys(ART_KEYWORDS.values()))}
+    properties: dict[str, Any]  # type: ignore[misc]  # instance-level, populated from config
+
+    def __init__(self, art_keywords: dict[str, str]) -> None:
+        super().__init__()
+        self.art_keywords = art_keywords
+        self.properties = {"other": list(dict.fromkeys(art_keywords.values()))}
 
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         to_remove: list[Match] = []
@@ -270,7 +261,7 @@ class ImageArtKeywordToOther(Rule):
                 predicate=lambda match: match.name in ("title", "alternative_title", "episode_title"),
             ):
                 key = re.sub(r"[\s._-]+", "", str(candidate.value or "").strip().lower())
-                canonical = ART_KEYWORDS.get(key)
+                canonical = self.art_keywords.get(key)
                 if not canonical:
                     continue
                 to_remove.append(candidate)

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -32,10 +32,6 @@ if TYPE_CHECKING:
 
     from rebulk.match import Matches
 
-# Articles that, when they make up the whole detected title, should swallow the following
-# property word (e.g. "The" + edition "Collector" -> title "The Collector").
-ARTICLES = frozenset({"the", "a", "an", "le", "la", "les", "el", "los", "las", "il", "lo", "l"})
-
 # Tags that mark a country/other match as a recognized release tag (edition, scene or
 # streaming-service keyword) rather than a real title word — such a token must never be
 # relabelled as the title even when it sits at the title position.
@@ -49,39 +45,6 @@ NON_LATIN_SCRIPT_RE = re.compile(
     r"　-〿぀-ヿ㐀-䶿一-鿿가-힯＀-￯]"
 )
 
-# Stop-words a title may legitimately end on: refuse cropping a trailing Title-Case
-# language/country that would otherwise leave the title ending on one of these
-# ("It Ends With Us" #789, "The Last of Us" #739, "Oshi no Ko" #745). An uppercase tag
-# ("...US") is still kept as a country by the Title-Case guard in KeepTrailingStopWordTitle.
-TITLE_STOP_WORDS = frozenset(
-    {
-        "the",
-        "a",
-        "an",
-        "and",
-        "or",
-        "of",
-        "to",
-        "in",
-        "on",
-        "at",
-        "for",
-        "from",
-        "by",
-        "with",
-        "into",
-        "onto",
-        "no",
-        "le",
-        "la",
-        "les",
-        "de",
-        "du",
-        "des",
-        "el",
-    }
-)
-
 
 def title(config: dict[str, Any]) -> Rebulk:
     """
@@ -92,15 +55,18 @@ def title(config: dict[str, Any]) -> Rebulk:
     :return: Created Rebulk object
     :rtype: Rebulk
     """
+    articles = frozenset(config.get("articles", ()))
+    title_stop_words = frozenset(config.get("title_stop_words", ()))
+
     rebulk = Rebulk(disabled=lambda context: is_disabled(context, "title"))
     rebulk.rules(
         CountryAtTitlePosition,
         TitleWordAtTitlePosition,
         TitleFromPosition,
         PreferTitleWithYear,
-        ExtendLoneArticleTitle,
+        ExtendLoneArticleTitle(articles),
         PropertyAtTitlePositionAsTitle,
-        KeepTrailingStopWordTitle,
+        KeepTrailingStopWordTitle(title_stop_words),
         SplitOriginalScriptTitle,
     )
 
@@ -631,11 +597,15 @@ class ExtendLoneArticleTitle(Rule):
     priority = -32
     consequence = RemoveMatch
 
+    def __init__(self, articles: frozenset[str]) -> None:
+        super().__init__()
+        self.articles = articles
+
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         input_string = matches.input_string or ""
         ret: list[tuple[Match, Match]] = []
         for title_match in matches.named("title", "episode_title"):
-            if str(title_match.value or "").strip().lower() not in ARTICLES:
+            if str(title_match.value or "").strip().lower() not in self.articles:
                 continue
             filepart = matches.markers.at_match(title_match, lambda m: m.name == "path", 0)
             if not filepart:
@@ -751,6 +721,10 @@ class KeepTrailingStopWordTitle(Rule):
     priority = POST_PROCESS
     consequence = RemoveMatch
 
+    def __init__(self, title_stop_words: frozenset[str]) -> None:
+        super().__init__()
+        self.title_stop_words = title_stop_words
+
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         input_string = matches.input_string or ""
         ret: list[tuple[Match, Match]] = []
@@ -777,7 +751,7 @@ class KeepTrailingStopWordTitle(Rule):
                 continue
             words = re.split(r"[^a-z0-9]+", str(title_match.value or "").lower())
             words = [w for w in words if w]
-            if not words or words[-1] not in TITLE_STOP_WORDS:
+            if not words or words[-1] not in self.title_stop_words:
                 continue
             ret.append((title_match, trailing))
         return ret

--- a/guessit/test/test_api.py
+++ b/guessit/test/test_api.py
@@ -166,3 +166,40 @@ def test_episode_words_accept_legacy_string_list() -> None:
     assert guessit("Sarja Kausi 2", config).get("season") == 2
     assert guessit("Vikings 3 Temporada 720p", config).get("season") == 3
     api.reset()
+
+
+def test_title_articles_overridable() -> None:
+    api.reset()
+    # A lone-article title swallows the following property word only for words in
+    # advanced_config.title.articles. "das" is not a default article, so adding it
+    # via config must make it behave like "the".
+    assert guessit("Das.Collector.2009.mkv").get("title") == "Das"
+    config = {"advanced_config": {"title": {"articles": ["das"]}}}
+    assert guessit("Das.Collector.2009.mkv", config).get("title") == "Das Collector"
+    api.reset()
+
+
+def test_title_stop_words_overridable() -> None:
+    api.reset()
+    # A trailing Title-Case country is kept in the title when cropping it would leave
+    # the title ending on a stop-word. "beyond" is not a default stop-word, so the
+    # country is dropped by default and kept once it is added via config.
+    default = guessit("Life.Beyond.Us.1080p.mkv")
+    assert default.get("title") == "Life Beyond"
+    assert str(default.get("country")) == "US"
+    config = {"advanced_config": {"title": {"title_stop_words": ["beyond"]}}}
+    overridden = guessit("Life.Beyond.Us.1080p.mkv", config)
+    assert overridden.get("title") == "Life Beyond Us"
+    assert overridden.get("country") is None
+    api.reset()
+
+
+def test_other_art_keywords_overridable() -> None:
+    api.reset()
+    # An artwork keyword filename is reclassified as `other` only for the keywords in
+    # advanced_config.other.art. "myart" is not a default keyword, so it stays a title
+    # until it is added via config.
+    assert guessit("Show/myart.jpg").get("other") is None
+    config = {"advanced_config": {"other": {"art": {"myart": "Poster"}}}}
+    assert guessit("Show/myart.jpg", config).get("other") == "Poster"
+    api.reset()


### PR DESCRIPTION
## Contexte

Le guide du projet (`CLAUDE.md`, section *Configuration*) impose que tout token / liste de mots vive dans la configuration (`options.json`, sous `advanced_config.<property>`) et soit threadé jusqu'à la règle via le `config` reçu par son builder, afin de rester surchargeable.

Trois vocabulaires enfreignaient encore cette règle. Cette PR les externalise (closes #892).

## Changements

- **`title.py`** — `ARTICLES` → `advanced_config.title.articles`
- **`title.py`** — `TITLE_STOP_WORDS` → `advanced_config.title.title_stop_words`
- **`other.py`** — `ART_KEYWORDS` → `advanced_config.other.art`

Les builders `title(config)` / `other(config)` lisent ces listes et les injectent dans les instances de règles (`ExtendLoneArticleTitle`, `KeepTrailingStopWordTitle`, `ImageArtKeywordToOther`). `title` n'est plus la seule propriété absente d'`advanced_config`.

Restent volontairement en code (hors périmètre) : regex, noms de tags internes (`RELEASE_TAG_MARKERS`, `STEREO_VR_CONTEXT_TAG`), et `VR_CONTEXT_VALUES`.

## Validation

- Plus aucun `frozenset`/dict littéral pour ces trois vocabulaires dans `title.py` / `other.py`.
- Listes surchargeables via `--config` / le dict `options` (fusion en union, comme les autres listes d'`advanced_config`).
- Schéma régénéré (identique — mêmes valeurs d'enum), `ruff` + `mypy` OK, suite complète : 2346 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)