### PR TITLE
docs(config): document list merge behaviour and the pristine option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,42 @@ Additional configuration files can be included using the `-c`/`--config`
 option.
 
 As many configuration files can be involved, they are deeply merged to
-keep all values inside the effective configuration.
+keep all values inside the effective configuration. The options passed
+programmatically to `guessit()` are merged last, on top of the files.
+
+# Merging and overriding values
+
+Merging keeps values from every source rather than replacing them:
+
+> -   scalar values (string, number, boolean) are replaced by the later source;
+> -   list values are concatenated (the later values are appended to the
+>     existing ones, skipping duplicates);
+> -   dict values are deeply merged, key by key.
+
+Because lists are concatenated, you cannot override a list option (such as
+`allowed_countries` or `allowed_languages`) simply by providing a new list:
+your values are added to the defaults instead of replacing them.
+
+```python
+>>> from guessit import guessit
+>>> guessit('SS-GB.S01E01.1080p.x265-MeGusta.mkv', {'allowed_countries': []})['country']
+<Country [GB]>
+```
+
+To drop the inherited value before merging, use the `pristine` option. Set it
+to `True` to reset the whole configuration, or to a list of option names to
+reset only those:
+
+```python
+>>> guessit('SS-GB.S01E01.1080p.x265-MeGusta.mkv',
+...         {'pristine': ['allowed_countries'], 'allowed_countries': []})['title']
+'SS-GB'
+```
+
+`pristine` is applied per source, resetting the matching options accumulated
+from the previous sources before the current one is merged in. It is available
+in configuration files and in the programmatic options, but not as a
+command-line flag.
 
 # Advanced configuration
 


### PR DESCRIPTION
## Context

Closes #610.

Issue #610 reported that programmatic options don't override `options.json` — specifically that passing `{'allowed_countries': []}` still detects a country. This is actually by design: **list** options are concatenated across configuration sources rather than replaced, so a new list is *added* to the defaults instead of overriding them.

The maintainer already pointed to the answer back in 2019 — the `pristine` option — noting it was *"lying in the code"* and *"sadly not documented"*. Since then `pristine` has been covered by tests (`test_options.py`), but it remained undocumented.

## Change

Documents in `docs/configuration.md`:

- the per-type merge behaviour (scalars replace, lists concatenate, dicts deep-merge);
- why a list option can't be overridden with a plain new list;
- the `pristine` option (`True` to reset everything, or a list of option names to reset those), available in config files and programmatic options but not as a CLI flag.

Both code examples were verified against the current build.

No behaviour change — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)