### PR TITLE
docs: move the supported-languages section from the README into the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,49 +29,21 @@ For example, GuessIt can do the following:
         "type": "episode"
     }
 
-More information is available at [guessit-io.github.io/guessit](https://guessit-io.github.io/guessit).
+Documentation
+-------------
+
+Full documentation is available at [guessit-io.github.io/guessit](https://guessit-io.github.io/guessit), including:
+
+- [Properties](https://guessit-io.github.io/guessit/properties/) guessit can extract
+- [Sources](https://guessit-io.github.io/guessit/sources/) it recognises
+- [Configuration](https://guessit-io.github.io/guessit/configuration/) and advanced options
+- [Supported languages](https://guessit-io.github.io/guessit/languages/) for season/episode keywords and spoken/subtitle detection
+- [Known limitations](https://guessit-io.github.io/guessit/known-limitations/)
 
 JavaScript / TypeScript port
 ----------------------------
 
 Looking for a JavaScript implementation? [guessit-js](https://github.com/opensubtitles/guessit-js) is a third-party TypeScript/WASM port (maintained by [OpenSubtitles](https://www.opensubtitles.org)) that runs in Node, browsers and WASM with no Python required. It is not affiliated with this project.
-
-Supported languages
--------------------
-
-GuessIt handles two independent notions of "language".
-
-**Season / episode keywords.** Beyond English, GuessIt recognises season and
-episode markers written in several languages, in both `keyword number` and
-`number keyword` order (e.g. `Temporada 2` and `2ª Temporada`, `Сезон 3` and
-`3 сезон`), as well as the compact `T02E22` / `T01XE08` form:
-
-| Language | Season | Episode |
-|---|---|---|
-| English | `season`, `seasons` | `episode(s)`, `ep`, `eps` |
-| French | `saison`, `saisons` | `épisode(s)` |
-| Dutch | `seizoen` | `aflevering`, `afl` |
-| German | `staffel` (also `2. Staffel`) | `folge` |
-| Spanish / Portuguese | `temporada(s)`, `tem`, `temp` (with ordinals `1ª`/`04ª`/`3º`) | `capítulo(s)`, `episodio(s)` |
-| Italian | `stagione` | `episodio` |
-| Polish | `sezon` | `odcinek` |
-| Romanian | `sezonul` | `episodul` |
-| Hungarian | `2. évad` | `5. rész` |
-| Scandinavian | `säsong`, `sesong`, `sæson` | `avsnitt` |
-| Russian | `сезон` (incl. `5-й сезон`, `Сезон №9`) | `серия`, `серии`, `эпизод` |
-| Turkish | `sezon` | `bölüm` |
-| Japanese / Chinese | `第…季`, `シーズン…`, `…期` | `第…話`, `第…集` |
-
-Episode numbers are also detected for the plain English `episode` spelling
-regardless of the title's language. These keyword lists are configurable — see
-the [configuration docs](https://guessit-io.github.io/guessit/configuration/).
-
-**Spoken / subtitle language.** The `language` and `subtitle_language`
-properties detect the audio and subtitle language from tags such as `VOSTFR`,
-`MULTi`, `ITA`, `ENG`, … and resolve them through
-[babelfish](https://github.com/Diaoul/babelfish), which covers essentially every
-ISO 639 language. Use the `allowed_languages` option to restrict the recognised
-set.
 
 Support
 -------

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,0 +1,38 @@
+# Supported languages
+
+GuessIt handles two independent notions of "language".
+
+## Season / episode keywords
+
+Beyond English, GuessIt recognises season and episode markers written in
+several languages, in both `keyword number` and `number keyword` order
+(e.g. `Temporada 2` and `2ª Temporada`, `Сезон 3` and `3 сезон`), as well as
+the compact `T02E22` / `T01XE08` form:
+
+| Language | Season | Episode |
+|---|---|---|
+| English | `season`, `seasons` | `episode(s)`, `ep`, `eps` |
+| French | `saison`, `saisons` | `épisode(s)` |
+| Dutch | `seizoen` | `aflevering`, `afl` |
+| German | `staffel` (also `2. Staffel`) | `folge` |
+| Spanish / Portuguese | `temporada(s)`, `tem`, `temp` (with ordinals `1ª`/`04ª`/`3º`) | `capítulo(s)`, `episodio(s)` |
+| Italian | `stagione` | `episodio` |
+| Polish | `sezon` | `odcinek` |
+| Romanian | `sezonul` | `episodul` |
+| Hungarian | `2. évad` | `5. rész` |
+| Scandinavian | `säsong`, `sesong`, `sæson` | `avsnitt` |
+| Russian | `сезон` (incl. `5-й сезон`, `Сезон №9`) | `серия`, `серии`, `эпизод` |
+| Turkish | `sezon` | `bölüm` |
+| Japanese / Chinese | `第…季`, `シーズン…`, `…期` | `第…話`, `第…集` |
+
+Episode numbers are also detected for the plain English `episode` spelling
+regardless of the title's language. These keyword lists are configurable — see
+the [configuration docs](configuration.md).
+
+## Spoken / subtitle language
+
+The `language` and `subtitle_language` properties detect the audio and subtitle
+language from tags such as `VOSTFR`, `MULTi`, `ITA`, `ENG`, … and resolve them
+through [babelfish](https://github.com/Diaoul/babelfish), which covers
+essentially every ISO 639 language. Use the `allowed_languages` option to
+restrict the recognised set.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
   - Properties: properties.md
   - Sources: sources.md
   - Configuration: configuration.md
+  - Languages: languages.md
   - Known limitations: known-limitations.md
   - Migration (2.x to 3.x): migration2to3.md
   - Migration (1.x to 2.x): migration.md


### PR DESCRIPTION
Closes #897.

## Change

- New docs page `docs/languages.md` holding the moved content, split into two `##` sections:
  - **Season / episode keywords** — the per-language keyword table + the `keyword number` / `number keyword` explanation, linking to the configuration docs.
  - **Spoken / subtitle language** — `language` / `subtitle_language`, babelfish/ISO 639, `allowed_languages`.
- Registered the page in the `mkdocs.yml` nav (after *Configuration*).
- Removed the languages section from `README.md` and replaced the lone "More information is available at …" line with a proper **Documentation** section linking to the whole docs site (properties, sources, configuration, languages, known limitations).

## Verification

- `mkdocs build --strict` succeeds with no page warnings (relative link and nav entry resolve).

Documentation-only reorganisation — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)