### PR TITLE
docs: drop the Sources link from the README documentation list

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Documentation
 Full documentation is available at [guessit-io.github.io/guessit](https://guessit-io.github.io/guessit), including:
 
 - [Properties](https://guessit-io.github.io/guessit/properties/) guessit can extract
-- [Sources](https://guessit-io.github.io/guessit/sources/) it recognises
 - [Configuration](https://guessit-io.github.io/guessit/configuration/) and advanced options
 - [Supported languages](https://guessit-io.github.io/guessit/languages/) for season/episode keywords and spoken/subtitle detection
 - [Known limitations](https://guessit-io.github.io/guessit/known-limitations/)


### PR DESCRIPTION
Follow-up to #898.

The `Sources` docs page (`docs/sources.md`) is *Getting the source code* — how to clone/download the repository — not the media sources guessit recognises. Listing it in the README's **Documentation** overview was misleading, so this removes that entry.

Documentation-only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)