### PR TITLE
docs(properties): document missing properties and guard against schema drift

### DIFF
--- a/docs/properties.md
+++ b/docs/properties.md
@@ -83,6 +83,15 @@ Episode properties
 
     Episode number. (Can be a list if several are found)
 
+-   **episode\_title**
+
+    Title of the episode.
+
+-   **absolute\_episode**
+
+    Absolute episode number, mainly used by anime for continuous numbering
+    across seasons. (Can be a list if several are found)
+
 -   **disc**
 
     Disc number. (Can be a list if several are found)
@@ -137,6 +146,20 @@ Video properties
 -   **aspect\_ratio**
 
     Aspect ratio of video. Calculated using width and height from `screen_size`
+
+-   **width**
+
+    Pixel width parsed from an explicit `<width>x<height>` resolution. A
+    component used to compute `screen_size`; rarely emitted on its own.
+
+-   **height**
+
+    Pixel height parsed from the resolution. A component used to compute
+    `screen_size`; rarely emitted on its own.
+
+-   **scan\_type**
+
+    Scan type component of `screen_size`: `i` (interlaced) or `p` (progressive).
 
 -   **video\_codec**
 
@@ -235,6 +258,11 @@ Other properties
 
     CRC32 of the file.
 
+-   **proper\_count**
+
+    Number of `Proper` / `Repack` markers found (see `Proper` in `other`),
+    counting how many times the release was re-issued.
+
 -   **uuid**
 
     Volume identifier (UUID).
@@ -273,9 +301,11 @@ Other properties
 
     Film title of this movie.
 
--   **film\_series**
+-   **another**
 
-    Film series of this movie.
+    Internal secondary tag (e.g. `Reencoded` found alongside a source) that is
+    always renamed to `other` before output. Advertised for completeness; it
+    does not appear as a standalone property in results.
 
 -   **other**
 

--- a/guessit/test/test_schema.py
+++ b/guessit/test/test_schema.py
@@ -18,6 +18,7 @@ from guessit.yamlutils import OrderedDictYAMLLoader
 ROOT = Path(__file__).resolve().parent.parent.parent
 TEST_DIR = ROOT / "guessit" / "test"
 OUTPUT_SCHEMA_JSON = ROOT / "guessit" / "data" / "output-schema.json"
+PROPERTIES_DOC = ROOT / "docs" / "properties.md"
 
 
 def _corpus_inputs() -> list[str]:
@@ -69,6 +70,14 @@ def test_properties_advertises_every_schema_property() -> None:
     for name in GUESSIT_SCHEMA:
         assert name in props, f"properties() missing {name}"
     assert len(props) == len(GUESSIT_SCHEMA)
+
+
+def test_properties_doc_documents_every_schema_property() -> None:
+    """docs/properties.md must carry an entry for every schema property."""
+    doc = PROPERTIES_DOC.read_text(encoding="utf-8")
+    documented = {match.replace("\\", "") for match in re.findall(r"\*\*([^*]+)\*\*", doc)}
+    missing = [name for name in GUESSIT_SCHEMA if name not in documented]
+    assert not missing, f"docs/properties.md missing entries for: {sorted(missing)}"
 
 
 def test_value_constrained_properties_expose_a_non_empty_enum() -> None:


### PR DESCRIPTION
Closes #900.

## Change

`docs/properties.md` had drifted from `GUESSIT_SCHEMA`:

- **Added** entries for the 7 advertised-but-undocumented properties: `episode_title`, `absolute_episode`, `width`, `height`, `scan_type`, `proper_count`, `another`.
  - `width` / `height` / `scan_type` are documented as the internal components of `screen_size` (rarely emitted standalone).
  - `another` is documented honestly as an internal secondary tag always renamed to `other` before output (advertised by `-p` / the schema, but never a standalone result key).
- **Removed** the stale `film_series` entry (the schema exposes `film` / `film_title`).
- **Added** `test_properties_doc_documents_every_schema_property` in `test_schema.py`: asserts every `GUESSIT_SCHEMA` key has a `**property**` entry in `properties.md`, so the list cannot silently drift again.

## Verification

- `pytest guessit/test/test_schema.py` — 9 passed (incl. the new guard).
- `mkdocs build --strict` — clean.
- ruff + mypy clean on the touched test file.

## Note (out of scope)

`another`, `width`, `height` and `scan_type` are advertised by `guessit -p` / the schema even though they are internal matches that don't surface as standalone output keys. Whether they *should* be advertised is a separate question from documenting them; left as-is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)