### PR TITLE
docs(index): drop the stale CLI help dump and fix the REST API note

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,92 +56,14 @@ You can also [install GuessIt from sources](./sources.md)
 Usage
 -----
 
-GuessIt can be used from command line:
+GuessIt can be used from the command line:
 
+```bash
+$ guessit "Treme.1x03.Right.Place,.Wrong.Time.HDTV.XviD-NoTV.avi"
 ```
-usage: guessit [-h] [-t TYPE] [-n] [-Y] [-D] [-L ALLOWED_LANGUAGES]
-               [-C ALLOWED_COUNTRIES] [-E] [-T EXPECTED_TITLE]
-               [-G EXPECTED_GROUP] [--includes INCLUDES] [--excludes EXCLUDES]
-               [-f INPUT_FILE] [-v] [-P SHOW_PROPERTY] [-a] [-s] [-l] [-j]
-               [-y] [-i] [-c CONFIG] [--no-user-config] [--no-default-config]
-               [-p] [-V] [--version]
-               [filename [filename ...]]
 
-positional arguments:
-  filename              Filename or release name to guess
-
-optional arguments:
-  -h, --help            show this help message and exit
-
-Naming:
-  -t TYPE, --type TYPE  The suggested file type: movie, episode. If undefined,
-                        type will be guessed.
-  -n, --name-only       Parse files as name only, considering "/" and "\" like
-                        other separators.
-  -Y, --date-year-first
-                        If short date is found, consider the first digits as
-                        the year.
-  -D, --date-day-first  If short date is found, consider the second digits as
-                        the day.
-  -L ALLOWED_LANGUAGES, --allowed-languages ALLOWED_LANGUAGES
-                        Allowed language (can be used multiple times)
-  -C ALLOWED_COUNTRIES, --allowed-countries ALLOWED_COUNTRIES
-                        Allowed country (can be used multiple times)
-  -E, --episode-prefer-number
-                        Guess "serie.213.avi" as the episode 213. Without this
-                        option, it will be guessed as season 2, episode 13
-  -T EXPECTED_TITLE, --expected-title EXPECTED_TITLE
-                        Expected title to parse (can be used multiple times)
-  -G EXPECTED_GROUP, --expected-group EXPECTED_GROUP
-                        Expected release group (can be used multiple times)
-  --includes INCLUDES   List of properties to be detected
-  --excludes EXCLUDES   List of properties to be ignored
-
-Input:
-  -f INPUT_FILE, --input-file INPUT_FILE
-                        Read filenames from an input text file. File should
-                        use UTF-8 charset.
-
-Output:
-  -v, --verbose         Display debug output
-  -P SHOW_PROPERTY, --show-property SHOW_PROPERTY
-                        Display the value of a single property (title, series,
-                        video_codec, year, ...)
-  -a, --advanced        Display advanced information for filename guesses, as
-                        json output
-  -s, --single-value    Keep only first value found for each property
-  -l, --enforce-list    Wrap each found value in a list even when property has
-                        a single value
-  -j, --json            Display information for filename guesses as json
-                        output
-  -y, --yaml            Display information for filename guesses as yaml
-                        output
-  -i, --output-input-string
-                        Add input_string property in the output
-
-Configuration:
-  -c CONFIG, --config CONFIG
-                        Filepath to configuration file. Configuration file
-                        contains the same options as those from command line
-                        options, but option names have "-" characters replaced
-                        with "_". This configuration will be merged with
-                        default and user configuration files.
-  --no-user-config      Disable user configuration. If not defined, guessit
-                        tries to read configuration files at
-                        ~/.guessit/options.(json|yml|yaml) and
-                        ~/.config/guessit/options.(json|yml|yaml)
-  --no-default-config   Disable default configuration. This should be done
-                        only if you are providing a full configuration through
-                        user configuration or --config option. If no
-                        "advanced_config" is provided by another configuration
-                        file, it will still be loaded from default
-                        configuration.
-
-Information:
-  -p, --properties      Display properties that can be guessed.
-  -V, --values          Display property values that can be guessed.
-  --version             Display the guessit version.
-```
+Run `guessit --help` for the full list of options. Use `guessit -p` to list the
+properties GuessIt can detect and `guessit -V` to list their possible values.
 
 It can also be used as a python module:
 
@@ -161,9 +83,7 @@ Find more about Guessit configuration at [configuration page](./configuration.md
 REST API
 --------
 
-A REST API will be available soon ...
-
-Sources are available in a dedicated [guessit-rest repository](https://github.com/Toilal/guessit-rest).
+A REST API is available as a separate project, [guessit-rest](https://github.com/Toilal/guessit-rest).
 
 Support
 -------


### PR DESCRIPTION
Closes #901.

## Change

`docs/index.md` carried content that had drifted from reality:

- The full hand-pasted `guessit --help` block (~80 lines) no longer matched the real output (`optional arguments:` → `options:`, `-t TYPE, --type TYPE` → `-t, --type TYPE`, `[filename [filename ...]]` → `[filename ...]`) and would keep drifting. Replaced with a short invocation example plus a pointer to `guessit --help`, `guessit -p` (list properties) and `guessit -V` (list values).
- The **REST API** section said *"A REST API will be available soon ..."* — it has been for years, and [guessit-rest](https://github.com/Toilal/guessit-rest) already exists. Reworded to point at it directly.

## Verification

- `mkdocs build --strict` — clean.

Documentation-only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)