### PR TITLE
feat(api): export properties and suggested_expected from the package

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -72,7 +72,7 @@ Several mechanisms expose what GuessIt can emit:
 - `properties()` — a dict mapping every property to the list of values it can
   produce (empty list for free-form values):
 
-      >>> from guessit.api import properties
+      >>> from guessit import properties
       >>> 'Blu-ray' in properties()['source']
       True
 
@@ -83,8 +83,9 @@ Several mechanisms expose what GuessIt can emit:
 - On the command line, `guessit -p` lists the properties and `guessit -V` lists
   their possible values.
 
-`GUESSIT_SCHEMA` is exported from the top-level package; `properties()` and
-`suggested_expected()` live in `guessit.api` (or as methods on `GuessItApi`).
+`GUESSIT_SCHEMA`, `properties()` and `suggested_expected()` are all exported
+from the top-level `guessit` package (and are also available as methods on
+`GuessItApi`).
 
 ### `suggested_expected(titles)`
 
@@ -92,7 +93,7 @@ Given an iterable of known titles, return the subset that GuessIt would
 mis-parse into extra properties — good candidates to feed back as
 `expected_title`:
 
-    >>> from guessit.api import suggested_expected
+    >>> from guessit import suggested_expected
     >>> suggested_expected(['OSS 117', 'The 100', 'Normal Movie Title'])
     ['The 100']
 

--- a/guessit/__init__.py
+++ b/guessit/__init__.py
@@ -5,11 +5,20 @@ Extracts as much information as possible from a video file.
 
 from . import monkeypatch as _monkeypatch
 from .__version__ import __version__
-from .api import GuessItApi, guessit
+from .api import GuessItApi, guessit, properties, suggested_expected
 from .options import ConfigurationException
 from .rules.common.quantity import Size
 from .schema import GUESSIT_SCHEMA
 
-__all__ = ["GUESSIT_SCHEMA", "ConfigurationException", "GuessItApi", "Size", "__version__", "guessit"]
+__all__ = [
+    "GUESSIT_SCHEMA",
+    "ConfigurationException",
+    "GuessItApi",
+    "Size",
+    "__version__",
+    "guessit",
+    "properties",
+    "suggested_expected",
+]
 
 _monkeypatch.monkeypatch_rebulk()

--- a/guessit/test/test_api.py
+++ b/guessit/test/test_api.py
@@ -70,6 +70,23 @@ def test_properties() -> None:
     assert "video_codec" in props
 
 
+def test_public_api_is_exported_from_the_package() -> None:
+    import guessit as pkg
+
+    expected = {
+        "GUESSIT_SCHEMA",
+        "ConfigurationException",
+        "GuessItApi",
+        "Size",
+        "guessit",
+        "properties",
+        "suggested_expected",
+    }
+    assert expected <= set(pkg.__all__)
+    for name in expected:
+        assert hasattr(pkg, name), f"guessit.{name} is not exported"
+
+
 def test_list_value_not_mutated_between_guesses() -> None:
     # Regression for #822: a config pattern with a list value (compound edition)
     # used to be aliased into the result and mutated in place, leaking state into


### PR DESCRIPTION
## Context

`properties()` and `suggested_expected()` are documented as part of guessit's public API (they are listed as such in `CLAUDE.md`), but they were only re-exported through `guessit.api` — `from guessit import properties` raised `ImportError`. Surfaced while writing the API docs (#902).

## Change

- Re-export `properties` and `suggested_expected` from the top-level `guessit` package and add them to `__all__`.
- Add `test_public_api_is_exported_from_the_package` locking the exported names.
- Update `docs/api.md` to use the top-level import (`from guessit import properties` / `suggested_expected`).

Purely additive — no existing import path changes.

## Verification

- `from guessit import properties, suggested_expected` now works.
- `pytest guessit/test/test_api.py` — 20 passed.
- ruff + mypy clean; `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)