### PR TITLE
docs(index): update the MatchesDict repr to the current form

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ It can also be used as a python module:
 
     >>> from guessit import guessit
     >>> guessit('Treme.1x03.Right.Place,.Wrong.Time.HDTV.XviD-NoTV.avi')
-    MatchesDict([('title', 'Treme'), ('season', 1), ('episode', 3), ('episode_title', 'Right Place, Wrong Time'), ('source', 'HDTV'), ('video_codec', 'Xvid'), ('release_group', 'NoTV'), ('container', 'avi'), ('mimetype', 'video/x-msvideo'), ('type', 'episode')])
+    MatchesDict({'title': 'Treme', 'season': 1, 'episode': 3, 'episode_title': 'Right Place, Wrong Time', 'source': 'HDTV', 'video_codec': 'Xvid', 'release_group': 'NoTV', 'container': 'avi', 'mimetype': 'video/x-msvideo', 'type': 'episode'})
 
 `MatchesDict` is a dict that keeps matches ordering.
 


### PR DESCRIPTION
The home page python example still showed the old `MatchesDict([('title', 'Treme'), ...])` list-of-tuples repr. The current `MatchesDict` renders as a dict literal (`MatchesDict({'title': 'Treme', ...})`). Updated to match the real output (verified against the current build).

Documentation-only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)