### PR TITLE
ci(docs): publish a develop docs preview under /dev/

### DIFF
--- a/.github/workflows/mkdocs-develop.yml
+++ b/.github/workflows/mkdocs-develop.yml
@@ -1,8 +1,8 @@
-name: mkdocs
+name: mkdocs-develop
 on:
   push:
     branches:
-      - main
+      - develop
 concurrency:
   group: gh-pages-deploy
   cancel-in-progress: false
@@ -19,13 +19,12 @@ jobs:
 
       - run: uvx --with mkdocs-material mkdocs build
 
-      - name: Deploy 🚀
+      - name: Deploy develop preview 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
           folder: site
+          # Publish the develop build under /dev/ without touching the stable site at the root.
+          target-folder: dev
           clean: true
-          # Preserve the develop preview published under dev/ by the mkdocs-develop workflow.
-          clean-exclude: |
-            dev


### PR DESCRIPTION
## Goal

Serve a live preview of the `develop` docs alongside the stable site, on the same GitHub Pages site (GitHub allows only one Pages site per repo, so this uses a subpath rather than a second site):

- stable (from `main`): `https://guessit-io.github.io/guessit/`
- develop preview: `https://guessit-io.github.io/guessit/dev/`

## How

- **New `mkdocs-develop.yml`** (on push to `develop`): builds the docs and deploys them into the `dev/` subfolder of `gh-pages` via `target-folder: dev`. `clean: true` here is scoped by rsync to the `dev/` destination, so the root site is untouched.
- **`mkdocs.yml`** (on push to `main`): now keeps `clean: true` but adds `clean-exclude: dev` so a release deploy preserves the preview, and **drops `single-commit`** — a single/orphan commit would recreate the branch from scratch and wipe `dev/`.
- Both workflows share `concurrency.group: gh-pages-deploy` (`cancel-in-progress: false`) so the two deploys to `gh-pages` serialize instead of racing.

## Feasibility check

Verified against the action source (`src/git.ts`): rsync deploys into `${tmp}/${target-folder}` and `--delete` only prunes that destination, so a `target-folder: dev` deploy cannot delete root files; and `clean-exclude` adds `--exclude dev` to the root deploy's `--delete`. YAML of both workflows validated.

## Post-merge verification

Merging this to `develop` triggers `mkdocs-develop`; I'll confirm `/guessit/dev/` serves the develop docs and `/guessit/` (stable) is untouched.

## Caveat

The `/dev/` build inherits `site_url` (root), so canonical/sitemap URLs point at the root — cosmetic only; in-page navigation and assets are relative and work under the subpath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)