### PR TITLE
ci(docs): publish per-MR docs previews for docs/* branches

### DIFF
--- a/.github/workflows/mkdocs-preview.yml
+++ b/.github/workflows/mkdocs-preview.yml
@@ -1,0 +1,67 @@
+name: mkdocs-preview
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+permissions:
+  contents: write
+jobs:
+  deploy:
+    # Same-repo docs/* PRs only: fork PRs get a read-only token and cannot push to gh-pages.
+    if: >-
+      github.event.action != 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'docs/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Compute preview slug
+        id: slug
+        run: |
+          name="${GITHUB_HEAD_REF#docs/}"
+          name="$(printf '%s' "$name" | tr '/' '-' | tr -cd '[:alnum:]._-')"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - run: uvx --with mkdocs-material mkdocs build
+
+      - name: Deploy MR preview 🚀
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          folder: site
+          # Publish under preview/<branch-without-docs>/ without touching the rest of gh-pages.
+          target-folder: preview/${{ steps.slug.outputs.name }}
+          clean: true
+
+  cleanup:
+    # When a docs/* PR is merged or closed, remove its preview folder.
+    if: >-
+      github.event.action == 'closed'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && startsWith(github.head_ref, 'docs/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: gh-pages
+      - name: Remove preview folder
+        run: |
+          name="${GITHUB_HEAD_REF#docs/}"
+          name="$(printf '%s' "$name" | tr '/' '-' | tr -cd '[:alnum:]._-')"
+          if [ -d "preview/$name" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git rm -r "preview/$name"
+            git commit -m "chore(docs): remove MR preview for ${name}"
+            git push
+          else
+            echo "No preview folder preview/${name} to remove."
+          fi

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -26,6 +26,8 @@ jobs:
           branch: gh-pages
           folder: site
           clean: true
-          # Preserve the develop preview published under dev/ by the mkdocs-develop workflow.
+          # Preserve the develop preview (dev/) and the docs/* MR previews (preview/)
+          # published by the mkdocs-develop and mkdocs-preview workflows.
           clean-exclude: |
             dev
+            preview


### PR DESCRIPTION
## Goal

Give every `docs/*` pull request a live preview of its built docs, and tear it down when the PR is merged or closed.

- preview URL: `https://guessit-io.github.io/guessit/preview/<branch-without-docs>/`
- e.g. `docs/api-options-reference-902` → `…/preview/api-options-reference-902/`

## How

New **`mkdocs-preview.yml`** on `pull_request` (`opened`, `synchronize`, `reopened`, `closed`):

- **deploy** job — for same-repo PRs whose head is `docs/*` (not `closed`): build and deploy into `gh-pages/preview/<slug>/` via `target-folder`. `clean: true` is scoped by rsync to that subfolder, so the root, `dev/` and other previews are untouched. The slug is the branch name minus `docs/`, with `/` → `-` and non-`[alnum._-]` stripped.
- **cleanup** job — on `closed` (merge or close) of a same-repo `docs/*` PR: `git rm -r preview/<slug>` on `gh-pages` and push.

Also:
- **`mkdocs.yml`** (release): `clean-exclude` now lists `dev` **and** `preview`, so a release deploy preserves all previews.
- All three docs workflows share `concurrency.group: gh-pages-deploy` so deploys to `gh-pages` serialize instead of racing.

## Notes / limits

- **Fork PRs are skipped** (`head.repo.full_name == github.repository` guard): a fork PR only gets a read-only `GITHUB_TOKEN` and could not push to `gh-pages` anyway — this avoids noisy failures. Previews work for the same-repo `docs/*` branches used here.
- YAML validated and the slug logic checked against several branch-name shapes.

## Post-merge verification

I'll smoke-test with a throwaway `docs/*` PR: confirm the preview appears at `…/preview/<name>/`, then close it and confirm the folder is removed (root and `dev/` untouched throughout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)