### PR TITLE
ci(docs): use per-target concurrency groups for gh-pages deploys

### DIFF
--- a/.github/workflows/mkdocs-develop.yml
+++ b/.github/workflows/mkdocs-develop.yml
@@ -3,9 +3,12 @@ on:
   push:
     branches:
       - develop
+# Per-target group: coalesce rapid develop pushes to the latest build, without
+# cancelling the main/preview deploys. Concurrent pushes to disjoint gh-pages
+# folders are handled by the deploy action's fetch+rebase+retry.
 concurrency:
-  group: gh-pages-deploy
-  cancel-in-progress: false
+  group: gh-pages-develop
+  cancel-in-progress: true
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/mkdocs-preview.yml
+++ b/.github/workflows/mkdocs-preview.yml
@@ -2,9 +2,13 @@ name: mkdocs-preview
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+# Per-PR group: a new push (or the close/cleanup) supersedes an in-flight build
+# for the same PR, without touching other PRs' or the main/develop deploys.
+# Concurrent pushes to disjoint gh-pages folders are handled by the deploy
+# action's fetch+rebase+retry.
 concurrency:
-  group: gh-pages-deploy
-  cancel-in-progress: false
+  group: gh-pages-preview-${{ github.head_ref }}
+  cancel-in-progress: true
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -3,8 +3,11 @@ on:
   push:
     branches:
       - main
+# Per-target group: a release deploy is never cancelled by the develop/preview
+# workflows. Concurrent pushes to disjoint gh-pages folders are handled by the
+# deploy action's fetch+rebase+retry.
 concurrency:
-  group: gh-pages-deploy
+  group: gh-pages-main
   cancel-in-progress: false
 jobs:
   deploy:


### PR DESCRIPTION
## Problem

All three docs workflows shared one concurrency group (`gh-pages-deploy`). GitHub keeps at most **one pending run per concurrency group** and cancels the previously-pending one when a newer run joins. So when merging a `docs/*` PR fired both `mkdocs-develop` (push to develop) and `mkdocs-preview` cleanup (PR closed) into the same group, the `mkdocs-develop` run was **cancelled** — and the `/dev/` site never rebuilt (observed on the #915 merge).

## Fix

Per-target concurrency groups so targets never cancel each other:

- `mkdocs.yml` → `gh-pages-main` (cancel-in-progress: false)
- `mkdocs-develop.yml` → `gh-pages-develop` (cancel-in-progress: true)
- `mkdocs-preview.yml` → `gh-pages-preview-${{ github.head_ref }}` (cancel-in-progress: true)

Cross-target git races on `gh-pages` are safe: the deploy action pushes with fetch+rebase+retry (attempt limit 3), and the three targets write disjoint folders (`/`, `dev/`, `preview/<name>/`), so rebases apply cleanly.

## Verification

Merging this to develop should run `mkdocs-develop` to completion (not cancelled) and refresh `/dev/` — I'll confirm the run succeeds and `/dev/api/` reflects the latest content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)