### PR TITLE
fix: Fixed four spurious-number patterns in episodes.py: RemoveDetachedE

### DIFF
--- a/guessit/data/output-schema.json
+++ b/guessit/data/output-schema.json
@@ -1098,7 +1098,17 @@
       "type": "string"
     },
     "year": {
-      "type": "number"
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
+      ]
     }
   },
   "additionalProperties": true

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -531,11 +531,14 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     )
 
     rebulk.rules(
+        RemoveGroupIdSeasonEpisode,
         NumberFirstConflict(seps),
         WeakConflictSolver,
         RemoveInvalidSeason,
         RemoveInvalidEpisode,
         SeePatternRange([*range_separators, "_"]),
+        SeasonWordDashEpisode(range_separators),
+        ParenthesizedSeasonRangeAsEpisode,
         EpisodeNumberSeparatorRange(range_separators),
         SeasonSeparatorRange(range_separators),
         RemoveWeakIfMovie,
@@ -552,6 +555,54 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     )
 
     return rebulk
+
+
+class RemoveGroupIdSeasonEpisode(Rule):
+    """
+    A leading ``[0x<hex>]`` bracket (e.g. ``[0x539]``) is a release-group hex id, not season 0
+    x episode (#875). Left alone, the "N x EE" marker convention matches it and wins the
+    match-conflict resolution (it carries an "x" in its raw text) over a real ``S01E01``-style
+    match later in the name, corrupting both the season/episode and the release group.
+
+    Restricted to season 0 -- the hallmark of a "0x..." hex id -- and requires another
+    real season/episode match elsewhere, so a genuine bracketed "0x05" used as the only
+    season/episode indicator is left untouched.
+    """
+
+    priority = PRE_PROCESS + 1
+    consequence = RemoveMatch
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        to_remove: list[Match] = []
+        for filepart in matches.markers.named("path"):
+            # Closure consumed within this iteration; late binding (B023) is intentional and safe.
+            group = matches.markers.range(
+                filepart.start,
+                filepart.end,
+                lambda m: m.name == "group" and m.start == filepart.start,  # noqa: B023
+                0,
+            )
+            if not group:
+                continue
+            seasons = matches.range(
+                group.start,
+                group.end,
+                lambda m: m.name == "season" and m.value == 0 and "SxxExx" in m.tags,
+            )
+            if not seasons:
+                continue
+            other_season = matches.range(
+                group.end, filepart.end, lambda m: m.name == "season" and not m.private and "SxxExx" in m.tags, 0
+            )
+            if not other_season:
+                continue
+            for season in seasons:
+                initiator = season.initiator
+                if initiator.start != group.start + 1 or initiator.end != group.end - 1:
+                    continue
+                to_remove.append(initiator)
+                to_remove.extend(initiator.children)
+        return to_remove
 
 
 class NumberFirstConflict(Rule):
@@ -952,6 +1003,99 @@ class SeasonSeparatorRange(AbstractSeparatorRange):
         super().__init__(range_separators, "season")
 
 
+class SeasonWordDashEpisode(Rule):
+    """
+    Reinterpret a season-word chain's "Season N - EE" as season=N, episode=EE rather than a
+    season range N..EE (#875).
+
+    A dash glued directly to both digits ("Season.1-3") keeps reading as a genuine season
+    range/list (a common box-set naming convention, upstream #800-ish); a dash surrounded by
+    real separators on both sides ("Season 2 - 08") is the anime convention where the number
+    after the dash is the episode, not another season bound. A "Complete" (or similar pack
+    marker) later in the same filepart overrides this back to a genuine range: "Coupling Season
+    1 - 4 Complete DVDRip" is a season-pack release, not season 1 episode 4.
+    """
+
+    priority = 132
+    consequence = [RemoveMatch, RenameMatch("episode")]
+
+    def __init__(self, range_separators: list[str]) -> None:
+        super().__init__()
+        self.range_separators = range_separators
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        to_remove: list[Match] = []
+        to_rename: list[Match] = []
+        input_string = matches.input_string or ""
+
+        for separator in matches.named("seasonSeparator"):
+            if separator.value not in self.range_separators or "SxxExx" in separator.tags:
+                continue
+            # A word separator ("to", "a") always needs surrounding separators to tokenize at
+            # all ("Season 1 to 3"): it's never "tight", so it always reads as a genuine range.
+            if (separator.value or "").isalpha():
+                continue
+            previous_season = matches.previous(separator, lambda m: m.name == "season", 0)
+            next_season = matches.next(separator, lambda m: m.name == "season", 0)
+            if not previous_season or not next_season:
+                continue
+            initiator = separator.initiator
+            if len(initiator.children.named("season")) != 2:
+                continue
+            if not input_string[previous_season.end : separator.start]:
+                continue  # tight dash: a genuine season range/list
+            if not input_string[separator.end : next_season.start]:
+                continue
+            filepart = matches.markers.at_match(separator, lambda m: m.name == "path", 0)
+            if filepart and matches.range(
+                next_season.end, filepart.end, lambda m: m.name == "other" and str(m.value).lower() == "complete", 0
+            ):
+                continue  # a pack marker ("Complete") later on: a genuine season range/list
+            to_remove.append(separator)
+            to_rename.append(next_season)
+        return to_remove, to_rename
+
+
+class ParenthesizedSeasonRangeAsEpisode(Rule):
+    """
+    A parenthesized "(S<n>-<nn>)" directly after an absolute episode number is season n,
+    episode nn, not a season range n..nn (#875): "87 (S4-24)" -- 24 is the per-season episode
+    number annotating the absolute count 87, a convention distinct from a bracketed season-pack
+    range such as "[S01-07]" (upstream keeps that one a season list).
+
+    Restricted to round parentheses right after a bare episode-like number: a square-bracketed
+    "[S01-07]" or a parenthesized range with nothing in front of it is a genuine season range.
+    """
+
+    priority = 132
+    consequence = [RemoveMatch, RenameMatch("episode")]
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        to_remove: list[Match] = []
+        to_rename: list[Match] = []
+        for separator in matches.named("seasonSeparator", lambda m: "SxxExx" in m.tags):
+            initiator = separator.initiator
+            if len(initiator.children.named("season")) != 2:
+                continue
+            group = matches.markers.at_match(initiator, lambda m: m.name == "group", 0)
+            # EnlargeGroupMatches (processors.py) has already grown the chain match to the
+            # group's own span by this priority, so the bracket-wrapped case reads as equal
+            # spans rather than the raw off-by-one.
+            if not group or group.start != initiator.start or group.end != initiator.end:
+                continue
+            if (group.raw or "")[:1] != "(" or (group.raw or "")[-1:] != ")":
+                continue
+            absolute_number = matches.previous(group, lambda m: not m.private and "weak-episode" in m.tags, 0)
+            if not absolute_number or (matches.input_string or "")[absolute_number.end : group.start].strip():
+                continue
+            next_season = matches.next(separator, lambda m: m.name == "season", 0)
+            if not next_season:
+                continue
+            to_remove.append(separator)
+            to_rename.append(next_season)
+        return to_remove, to_rename
+
+
 class RemoveWeakIfMovie(Rule):
     """
     Remove weak-episode tagged matches if it seems to be a movie.
@@ -1190,9 +1334,15 @@ class EpisodeDetailValidator(Rule):
 
 class RemoveDetachedEpisodeNumber(Rule):
     """
-    If multiple episode are found, remove those that are not detached from a range and less than 10.
+    If multiple episodes are found, remove the one that doesn't belong.
 
-    Fairy Tail 2 - 16-20, 2 should be removed.
+    Fairy Tail 2 - 16-20: "2" is detached from the 16-20 range and less than 10, so it's
+    removed -- it's a part/season digit glued to the title, not an episode.
+
+    When there is no range (exactly two isolated numbers), the larger one is removed instead:
+    it's either a number embedded in the title (Mob Psycho 100 - 09, #875) or a duplicated
+    absolute episode count in parentheses (Fairy Tail 2 - 52 (227), #875), never the real
+    episode, whichever position it occupies in the release name.
     """
 
     priority = 64
@@ -1210,15 +1360,22 @@ class RemoveDetachedEpisodeNumber(Rule):
                 episode_values.add(match.value)
 
         episode_numbers = sorted(episode_numbers, key=lambda m: m.value)
-        if (
-            len(episode_numbers) > 1
+
+        outlier: Match | None = None
+        if len(episode_numbers) == 2:
+            if episode_numbers[1].value - episode_numbers[0].value != 1:
+                outlier = episode_numbers[1]
+        elif (
+            len(episode_numbers) > 2
             and episode_numbers[0].value < 10
             and episode_numbers[1].value - episode_numbers[0].value != 1
         ):
-            parent: Match | None = episode_numbers[0]
-            while parent:
-                ret.append(parent)
-                parent = parent.parent
+            outlier = episode_numbers[0]
+
+        parent: Match | None = outlier
+        while parent:
+            ret.append(parent)
+            parent = parent.parent
         return ret
 
 

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -1003,60 +1003,84 @@ class SeasonSeparatorRange(AbstractSeparatorRange):
         super().__init__(range_separators, "season")
 
 
-class SeasonWordDashEpisode(Rule):
+class AbstractSeasonSeparatorAsEpisode(Rule):
     """
-    Reinterpret a season-word chain's "Season N - EE" as season=N, episode=EE rather than a
-    season range N..EE (#875).
+    Shared machinery for reinterpreting a single-hop "season <sep> season" chain as
+    season=N, episode=M rather than a season range N..M (#875).
 
-    A dash glued directly to both digits ("Season.1-3") keeps reading as a genuine season
-    range/list (a common box-set naming convention, upstream #800-ish); a dash surrounded by
-    real separators on both sides ("Season 2 - 08") is the anime convention where the number
-    after the dash is the episode, not another season bound. A "Complete" (or similar pack
-    marker) later in the same filepart overrides this back to a genuine range: "Coupling Season
-    1 - 4 Complete DVDRip" is a season-pack release, not season 1 episode 4.
+    A subclass supplies the structural evidence (:meth:`applies`) that decides when a given
+    ``seasonSeparator`` hop is really an anime "absolute/season - episode" annotation rather
+    than a genuine season range/list; this base handles the shared single-hop guard and the
+    season -> episode rename once that evidence holds.
     """
 
     priority = 132
     consequence = [RemoveMatch, RenameMatch("episode")]
 
-    def __init__(self, range_separators: list[str]) -> None:
-        super().__init__()
-        self.range_separators = range_separators
+    def candidates(self, matches: Matches) -> Any:
+        """The ``seasonSeparator`` matches this subclass cares about."""
+        return matches.named("seasonSeparator")
+
+    def applies(self, matches: Matches, separator: Match, next_season: Match) -> bool:
+        """Whether this single-hop separator should be reinterpreted as season/episode."""
+        raise NotImplementedError
 
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         to_remove: list[Match] = []
         to_rename: list[Match] = []
-        input_string = matches.input_string or ""
-
-        for separator in matches.named("seasonSeparator"):
-            if separator.value not in self.range_separators or "SxxExx" in separator.tags:
-                continue
-            # A word separator ("to", "a") always needs surrounding separators to tokenize at
-            # all ("Season 1 to 3"): it's never "tight", so it always reads as a genuine range.
-            if (separator.value or "").isalpha():
-                continue
-            previous_season = matches.previous(separator, lambda m: m.name == "season", 0)
-            next_season = matches.next(separator, lambda m: m.name == "season", 0)
-            if not previous_season or not next_season:
-                continue
+        for separator in self.candidates(matches):
             initiator = separator.initiator
             if len(initiator.children.named("season")) != 2:
                 continue
-            if not input_string[previous_season.end : separator.start]:
-                continue  # tight dash: a genuine season range/list
-            if not input_string[separator.end : next_season.start]:
+            next_season = matches.next(separator, lambda m: m.name == "season", 0)
+            if not next_season:
                 continue
-            filepart = matches.markers.at_match(separator, lambda m: m.name == "path", 0)
-            if filepart and matches.range(
-                next_season.end, filepart.end, lambda m: m.name == "other" and str(m.value).lower() == "complete", 0
-            ):
-                continue  # a pack marker ("Complete") later on: a genuine season range/list
+            if not self.applies(matches, separator, next_season):
+                continue
             to_remove.append(separator)
             to_rename.append(next_season)
         return to_remove, to_rename
 
 
-class ParenthesizedSeasonRangeAsEpisode(Rule):
+class SeasonWordDashEpisode(AbstractSeasonSeparatorAsEpisode):
+    """
+    Reinterpret a season-word chain's "Season N - EE" as season=N, episode=EE rather than a
+    season range N..EE (#875).
+
+    A dash glued directly to both digits ("Season.1-3") keeps reading as a genuine season
+    range/list (a common box-set naming convention); a dash surrounded by real separators on
+    both sides ("Season 2 - 08") is the anime convention where the number after the dash is the
+    episode, not another season bound. Restricted to anime releases: this convention clashes
+    with the equally common western box-set range ("The Wire Season 1 - 5"), so it only applies
+    when other anime signals (see :meth:`WeakConflictSolver.is_anime`) are present (#920).
+    """
+
+    def __init__(self, range_separators: list[str]) -> None:
+        super().__init__()
+        self.range_separators = range_separators
+
+    def candidates(self, matches: Matches) -> Any:
+        return matches.named("seasonSeparator", lambda m: "SxxExx" not in m.tags)
+
+    def applies(self, matches: Matches, separator: Match, next_season: Match) -> bool:
+        if separator.value not in self.range_separators:
+            return False
+        # A word separator ("to", "a") always needs surrounding separators to tokenize at
+        # all ("Season 1 to 3"): it's never "tight", so it always reads as a genuine range.
+        if (separator.value or "").isalpha():
+            return False
+        previous_season = matches.previous(separator, lambda m: m.name == "season", 0)
+        if not previous_season:
+            return False
+        input_string = matches.input_string or ""
+        if not input_string[previous_season.end : separator.start]:
+            return False  # tight dash: a genuine season range/list
+        if not input_string[separator.end : next_season.start]:
+            return False
+        return WeakConflictSolver.is_anime(matches)
+
+
+class ParenthesizedSeasonRangeAsEpisode(AbstractSeasonSeparatorAsEpisode):
     """
     A parenthesized "(S<n>-<nn>)" directly after an absolute episode number is season n,
     episode nn, not a season range n..nn (#875): "87 (S4-24)" -- 24 is the per-season episode
@@ -1067,33 +1091,21 @@ class ParenthesizedSeasonRangeAsEpisode(Rule):
     "[S01-07]" or a parenthesized range with nothing in front of it is a genuine season range.
     """
 
-    priority = 132
-    consequence = [RemoveMatch, RenameMatch("episode")]
+    def candidates(self, matches: Matches) -> Any:
+        return matches.named("seasonSeparator", lambda m: "SxxExx" in m.tags)
 
-    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
-        to_remove: list[Match] = []
-        to_rename: list[Match] = []
-        for separator in matches.named("seasonSeparator", lambda m: "SxxExx" in m.tags):
-            initiator = separator.initiator
-            if len(initiator.children.named("season")) != 2:
-                continue
-            group = matches.markers.at_match(initiator, lambda m: m.name == "group", 0)
-            # EnlargeGroupMatches (processors.py) has already grown the chain match to the
-            # group's own span by this priority, so the bracket-wrapped case reads as equal
-            # spans rather than the raw off-by-one.
-            if not group or group.start != initiator.start or group.end != initiator.end:
-                continue
-            if (group.raw or "")[:1] != "(" or (group.raw or "")[-1:] != ")":
-                continue
-            absolute_number = matches.previous(group, lambda m: not m.private and "weak-episode" in m.tags, 0)
-            if not absolute_number or (matches.input_string or "")[absolute_number.end : group.start].strip():
-                continue
-            next_season = matches.next(separator, lambda m: m.name == "season", 0)
-            if not next_season:
-                continue
-            to_remove.append(separator)
-            to_rename.append(next_season)
-        return to_remove, to_rename
+    def applies(self, matches: Matches, separator: Match, next_season: Match) -> bool:
+        initiator = separator.initiator
+        group = matches.markers.at_match(initiator, lambda m: m.name == "group", 0)
+        # EnlargeGroupMatches (processors.py) has already grown the chain match to the
+        # group's own span by this priority, so the bracket-wrapped case reads as equal
+        # spans rather than the raw off-by-one.
+        if not group or group.start != initiator.start or group.end != initiator.end:
+            return False
+        if (group.raw or "")[:1] != "(" or (group.raw or "")[-1:] != ")":
+            return False
+        absolute_number = matches.previous(group, lambda m: not m.private and "weak-episode" in m.tags, 0)
+        return bool(absolute_number and not (matches.input_string or "")[absolute_number.end : group.start].strip())
 
 
 class RemoveWeakIfMovie(Rule):
@@ -1339,10 +1351,12 @@ class RemoveDetachedEpisodeNumber(Rule):
     Fairy Tail 2 - 16-20: "2" is detached from the 16-20 range and less than 10, so it's
     removed -- it's a part/season digit glued to the title, not an episode.
 
-    When there is no range (exactly two isolated numbers), the larger one is removed instead:
-    it's either a number embedded in the title (Mob Psycho 100 - 09, #875) or a duplicated
-    absolute episode count in parentheses (Fairy Tail 2 - 52 (227), #875), never the real
-    episode, whichever position it occupies in the release name.
+    When there is no range (exactly two isolated numbers) and the release is anime, the larger
+    one is removed instead: it's either a number embedded in the title (Mob Psycho 100 - 09,
+    #875) or a duplicated absolute episode count in parentheses (Fairy Tail 2 - 52 (227), #875),
+    never the real episode, whichever position it occupies in the release name. This is gated on
+    anime specifically: two isolated non-consecutive numbers are a legitimate two-episode list
+    outside of that convention (a bare "Show 12 - 24" keeps both, #920).
     """
 
     priority = 64
@@ -1363,7 +1377,7 @@ class RemoveDetachedEpisodeNumber(Rule):
 
         outlier: Match | None = None
         if len(episode_numbers) == 2:
-            if episode_numbers[1].value - episode_numbers[0].value != 1:
+            if episode_numbers[1].value - episode_numbers[0].value != 1 and WeakConflictSolver.is_anime(matches):
                 outlier = episode_numbers[1]
         elif (
             len(episode_numbers) > 2

--- a/guessit/schema.py
+++ b/guessit/schema.py
@@ -564,5 +564,5 @@ GUESSIT_SCHEMA: dict[str, PropertySchema] = {
     "website": {"type": ["string"], "array": False, "scalar": True},
     "week": {"type": ["number"], "array": False, "scalar": True},
     "width": {"type": ["string"], "array": False, "scalar": True},
-    "year": {"type": ["number"], "array": False, "scalar": True},
+    "year": {"type": ["number"], "array": True, "scalar": True},
 }

--- a/guessit/test/cross_parser/baseline.json
+++ b/guessit/test/cross_parser/baseline.json
@@ -191,9 +191,6 @@
     "[Hatsuyuki]_Kuroko_no_Basuke_S3_-_01_(51)_[720p][10bit][619C57A0].mkv": [
       "title"
     ],
-    "[Hiryuu] Maji de Watashi ni Koi Shinasai!! - 02 [720].mkv": [
-      "episode"
-    ],
     "[바카-Raws] Nekomonogatari (Black) #1-4 (BS11 1280x720 x264 AAC).mp4": [
       "title",
       "episode",
@@ -210,12 +207,8 @@
       "title",
       "episode"
     ],
-    "[Hatsuyuki] Dragon Ball Kai (2014) - 002 (100) [1280x720][DD66AFB7].mkv": [
-      "episode"
-    ],
     "[Deep] Tegami Bachi (REVERSE) - Letter Bee - 29 (04) [5203142B].mkv": [
-      "title",
-      "episode"
+      "title"
     ],
     "[FFF] Love Live! The School Idol Movie - PV [D1A15D2C].mkv": [
       "title"
@@ -225,9 +218,6 @@
     ],
     "[LRL] 1001 Nights (1998) [DVD]": [
       "title"
-    ],
-    "[Hatsuyuki-Kaitou]_Fairy_Tail_2_-_52_(227)_[720p][10bit][9DF6B8D5].mkv": [
-      "episode"
     ],
     "[NamaeNai] Hidamari Sketch x365 - 09a (DVD) [49874745].mkv": [
       "title"
@@ -258,9 +248,6 @@
     "[Judas] Aharen-san wa Hakarenai - S01E06v2.mkv": [
       "episode",
       "type"
-    ],
-    "[0x539] Somali and the Forest Spirit - S01E01 (WEB 1080p Hi10P AAC) [BB7C6531].mkv": [
-      "episode"
     ]
   },
   "go-ptn": {
@@ -426,9 +413,6 @@
     ],
     "1923 S02E01 1080p WEB H264-SuccessfulCrab": [
       "title"
-    ],
-    "[Anime Time] Naruto - 116 - 360 Degrees of Vision The Byakugan's Blind Spot.mkv": [
-      "episode"
     ],
     "Naruto Collection [DB 1080p][ Dual Audio ][ English & Arabic Sub ]": [
       "title"
@@ -622,26 +606,6 @@
     "[5.01] Weight Loss.avi": [
       "season"
     ],
-    "[Erai-raws] Granblue Fantasy The Animation Season 2 - 08 [1080p][Multiple Subtitle].mkv": [
-      "season"
-    ],
-    "[Erai-raws] Granblue Fantasy The Animation Season 2 - 10 [1080p][Multiple Subtitle].mkv": [
-      "season",
-      "episode"
-    ],
-    "[Erai-raws] Shingeki no Kyojin Season 3 - 11 (BD 1080p Hi10 FLAC) [1FA13150].mkv": [
-      "season"
-    ],
-    "[FFA] Kiratto Pri☆chan Season 3 - 11 [1080p][HEVC].mkv": [
-      "season"
-    ],
-    "[HR] Boku no Hero Academia 87 (S4-24) [1080p HEVC Multi-Subs] HR-GZ": [
-      "season",
-      "episode"
-    ],
-    "[SCY] Attack on Titan Season 3 - 11 (BD 1080p Hi10 FLAC) [1FA13150].mkv": [
-      "season"
-    ],
     "Доктор Хаус 03-20.mkv": [
       "season",
       "episode"
@@ -695,9 +659,6 @@
     "Mob.Psycho.100.II.E10.720p.WEB.x264-URANiME.mkv": [
       "episode"
     ],
-    "Mob Psycho 100 - 09 [1080p].mkv": [
-      "episode"
-    ],
     "MosGaz.(08.seriya).2012.WEB-DLRip(AVC).ExKinoRay.mkv": [
       "episode"
     ],
@@ -731,12 +692,6 @@
     "SupNat-11_06.avi": [
       "episode"
     ],
-    "Tajny.sledstviya-20.01.serya.WEB-DL.(1080p).by.lunkin.mkv": [
-      "episode"
-    ],
-    "The Amazing World of Gumball - 103 - The End - The Dress (720p.x264.ac3-5.1) [449].mkv": [
-      "episode"
-    ],
     "The Amazing World of Gumball - 103, 104 - The Third - The Debt.mkv": [
       "episode"
     ],
@@ -752,9 +707,6 @@
     "wwe.nxt.uk.11.26.mkv": [
       "episode"
     ],
-    "[92 Impatient Eilas & Miyafuji] Strike Witches - Road to Berlin - 01 [1080p][BCDFF6A2].mkv": [
-      "episode"
-    ],
     "[224] Shingeki no Kyojin - S03 - Part 1 - 13 [BDRip.1080p.x265.FLAC]": [
       "episode"
     ],
@@ -767,28 +719,16 @@
     "[Erai-raws] 3D Kanojo - Real Girl 2nd Season - 01 ~ 12 [720p]": [
       "episode"
     ],
-    "[Erai-raws] 22-7 - 11 .mkv": [
-      "episode"
-    ],
     "[Erai-raws] Carole and Tuesday - 01 ~ 12 [1080p][Multiple Subtitle]": [
       "episode"
     ],
-    "[Erai-raws] Shingeki no Kyojin Season 3 - 11 [1080p][Multiple Subtitle].mkv": [
-      "episode"
-    ],
     "[FFA] Koi to Producer: EVOL×LOVE - 01 - 12 [1080p][HEVC][AAC]": [
-      "episode"
-    ],
-    "[Golumpa] Star Blazers 2202 - 22 (Uchuu Senkan Yamato 2022) [FuniDub 1080p x264 AAC] [A24B89C8].mkv": [
       "episode"
     ],
     "Викинги / Vikings / Сезон: 5 / Серии: 5 из 20 [2017, WEB-DL 1080p] MVO": [
       "episode"
     ],
     "Мистер Робот / Mr. Robot / Сезон: 2 / Серии: 1-5 (12) [2016, США, WEBRip 1080p] MVO": [
-      "episode"
-    ],
-    "[SubsPlease] Fairy Tail - 100 Years Quest - 05 (1080p) [1107F3A9].mkv": [
       "episode"
     ],
     "[Beatrice-Raws] Evangelion 3.333 You Can (Not) Redo [BDRip 3840x1632 HEVC TrueHD]": [

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -1602,6 +1602,125 @@
   screen_size: 720p
   title: Fairy Tail 2
 
+# A title-internal number must not be merged into the episode list (#875)
+? Mob Psycho 100 - 09 [1080p].mkv
+: title: Mob Psycho 100
+  episode: 9
+  screen_size: 1080p
+  container: mkv
+  type: episode
+
+? '[Golumpa] Star Blazers 2202 - 22 (a.k.a. Yamato 2022) whatever'
+: release_group: Golumpa
+  title: Star Blazers 2202
+  episode: 22
+  year: 2022
+  season: 2022
+  episode_title: whatever
+  type: episode
+
+? '[SubsPlease] Fairy Tail - 100 Years Quest - 05 (1080p)'
+: release_group: SubsPlease
+  title: Fairy Tail
+  alternative_title: 100 Years Quest
+  episode: 5
+  screen_size: 1080p
+  type: episode
+
+# An absolute episode number in parentheses must not double-count the episode (#875)
+? '[Hatsuyuki-Kaitou]_Fairy_Tail_2_-_52_(227)_test'
+: release_group: Hatsuyuki-Kaitou
+  title: Fairy Tail 2
+  episode: 52
+  episode_title: test
+  type: episode
+
+? '[Hatsuyuki] Dragon Ball Kai (2014) - 002 (100) test'
+: release_group: Hatsuyuki
+  title: Dragon Ball Kai
+  year: 2014
+  season: 2014
+  episode: 2
+  episode_title: test
+  type: episode
+
+? '[Deep] Tegami Bachi (REVERSE) - Letter Bee - 29 (04) test'
+: release_group: Deep
+  title: Tegami Bachi
+  episode_title: Letter Bee - 29
+  episode: 4
+  type: episode
+
+# "Season N - EE" is season N, episode EE, not a season range N..EE (#875)
+? '[SCY] Attack on Titan Season 3 - 11 (BD 1080p Hi10 FLAC) [1FA13150].mkv'
+: release_group: SCY
+  title: Attack on Titan
+  season: 3
+  episode: 11
+  source: Blu-ray
+  screen_size: 1080p
+  video_profile: High 10
+  color_depth: 10-bit
+  audio_codec: FLAC
+  crc32: 1FA13150
+  container: mkv
+  type: episode
+
+? '[Erai-raws] Granblue Fantasy The Animation Season 2 - 08 [1080p][Multiple Subtitle].mkv'
+: release_group: Erai-raws
+  title: Granblue Fantasy The Animation
+  season: 2
+  episode: 8
+  screen_size: 1080p
+  subtitle_language: mul
+  container: mkv
+  type: episode
+
+? '[HR] Boku no Hero Academia 87 (S4-24) [1080p HEVC Multi-Subs] HR-GZ'
+: other: High Resolution
+  title: Boku no Hero Academia 87
+  season: 4
+  episode: 24
+  screen_size: 1080p
+  video_codec: H.265
+  video_profile: High Efficiency Video Coding
+  subtitle_language: mul
+  release_group: GZ
+  type: episode
+
+# A leading [0x539]-style group tag is a release group id, not season/episode (#875)
+? '[0x539] Somali and the Forest Spirit - S01E01 (WEB 1080p test)'
+: release_group: "0x539"
+  title: Somali and the Forest Spirit
+  season: 1
+  episode: 1
+  source: Web
+  screen_size: 1080p
+  type: episode
+
+# A "Season N - EE"-shaped range stays a genuine season list when a pack marker
+# ("Complete") follows -- it must not be reinterpreted as season N episode EE (#875)
+? Coupling Season 1 - 4 Complete DVDRip - x264 - MKV by RiddlerA
+: title: Coupling
+  season: [1, 2, 3, 4]
+  other: [Complete, Rip]
+  source: DVD
+  video_codec: H.264
+  container: mkv
+  release_group: RiddlerA
+  type: episode
+
+# A bracketed "[S01-07]" season range must not be reinterpreted as season+episode:
+# only a parenthesized range right after a bare absolute episode number is (#875)
+? Once Upon a Time [S01-07] (2011-2017) WEB-DLRip by Generalfilm
+: title: Once Upon a Time
+  season: [1, 2, 3, 4, 5, 6, 7]
+  year: [2011, 2017]
+  source: Web
+  other: Rip
+  release_group: Generalfilm
+  type: episode
+
 ? "Looney Tunes 1940x01 Porky's Last Stand.mkv"
 : episode: 1
   season: 1940

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -1721,6 +1721,22 @@
   release_group: Generalfilm
   type: episode
 
+# A bare two-episode list stays a list outside of anime -- only anime-signalled releases
+# reinterpret a dash-separated pair as season/episode or drop the outlier number (#920)
+? Show 12 - 24
+: title: Show
+  episode: [12, 24]
+
+# A spaced western box-set range ("Season 1 - 5") must stay a season list: the "N - EE"
+# reinterpretation is restricted to anime-signalled releases, since this convention clashes
+# with the anime "Season N - EE" = season N episode EE reading (#920)
+? The Wire Season 1 - 5 1080p BluRay
+: title: The Wire
+  season: [1, 2, 3, 4, 5]
+  screen_size: 1080p
+  source: Blu-ray
+  type: episode
+
 ? "Looney Tunes 1940x01 Porky's Last Stand.mkv"
 : episode: 1
   season: 1940


### PR DESCRIPTION
Fixes #875

## Summary
Fixed four spurious-number patterns in episodes.py: RemoveDetachedEpisodeNumber now drops the larger of two isolated weak-episode numbers (title digits, duplicated absolute episode in parens) instead of always assuming the smaller one is noise; two new rules (SeasonWordDashEpisode, ParenthesizedSeasonRangeAsEpisode) reinterpret a loose 'Season N - EE' or a parenthesized '(S<n>-<nn>)' after an absolute number as season+episode instead of a season range, while preserving genuine season-pack ranges (tight dashes, 'Complete' markers, bracketed '[S01-07]'); a new RemoveGroupIdSeasonEpisode rule stops a leading '[0x<hex>]' bracket from being parsed as season 0 x episode, letting the real SxxExx match and release group win. Added 11 regression cases to episodes.yml and regenerated the schema files.

## Changes
- `guessit/rules/properties/episodes.py`
- `guessit/test/episodes.yml`
- `guessit/schema.py`
- `guessit/data/output-schema.json`

## How this was tested
Ran `python.org/pypi/guessit)` locally.
