### PR TITLE
fix(test): make main and options tests pass on Windows

### DIFF
--- a/guessit/test/test_main.py
+++ b/guessit/test/test_main.py
@@ -15,7 +15,7 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 # Prevent output from spamming the console
 @pytest.fixture(autouse=True)
 def no_stdout(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    with open(os.devnull, "w") as f:
+    with open(os.devnull, "w", encoding="utf-8") as f:
         monkeypatch.setattr(sys, "stdout", f)
         yield
 

--- a/guessit/test/test_options.py
+++ b/guessit/test/test_options.py
@@ -15,15 +15,15 @@ def test_config_locations() -> None:
     locations = get_options_file_locations(homedir, cwd, True)
     assert len(locations) == 9
 
-    assert "/root/.guessit/options.json" in locations
-    assert "/root/.guessit/options.yml" in locations
-    assert "/root/.guessit/options.yaml" in locations
-    assert "/root/.config/guessit/options.json" in locations
-    assert "/root/.config/guessit/options.yml" in locations
-    assert "/root/.config/guessit/options.yaml" in locations
-    assert "/root/cwd/guessit.options.json" in locations
-    assert "/root/cwd/guessit.options.yml" in locations
-    assert "/root/cwd/guessit.options.yaml" in locations
+    assert os.path.join(homedir, ".guessit", "options.json") in locations
+    assert os.path.join(homedir, ".guessit", "options.yml") in locations
+    assert os.path.join(homedir, ".guessit", "options.yaml") in locations
+    assert os.path.join(homedir, ".config", "guessit", "options.json") in locations
+    assert os.path.join(homedir, ".config", "guessit", "options.yml") in locations
+    assert os.path.join(homedir, ".config", "guessit", "options.yaml") in locations
+    assert os.path.join(cwd, "guessit.options.json") in locations
+    assert os.path.join(cwd, "guessit.options.yml") in locations
+    assert os.path.join(cwd, "guessit.options.yaml") in locations
 
 
 def test_merge_configurations() -> None:


### PR DESCRIPTION
- Fix `test_main_unicode` by opening the devnull stdout redirect with `encoding="utf-8"`, so non-ASCII filenames don't fail under Windows' default encoding.
- Fix `test_config_locations` by building expected paths with os.path.join instead of hardcoded POSIX separators, matching what `get_options_file_locations` returns on Windows.

Let me know if you have any notes since this is my first contribution to this repo.