### PR TITLE
fix(screen_size): stop a p-less resolution from swallowing an x264 codec

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -166,6 +166,10 @@ The same shape as #533: a bare `720` / `1080` (resolution without the `p`) or a 
 them as a resolution or a runtime. The related **frame-rate** form *is* handled — `Gladiator 23.976
 FPS` correctly yields `frame_rate: 23.976fps` because the `FPS` suffix disambiguates it.
 
+An adjacent **video codec** does disambiguate it, and is handled since #933:
+`Les.Profs.2013.FRENCH.AC3.1080.x264-Ox` yields `screen_size: 1080p` + `video_codec: H.264`. The
+cases above have no such neighbour — `BrRip.264` is a stray number, not an `x264` codec token.
+
 ### #637 — a one-letter title followed by a number
 
 ```text

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -166,9 +166,11 @@ The same shape as #533: a bare `720` / `1080` (resolution without the `p`) or a 
 them as a resolution or a runtime. The related **frame-rate** form *is* handled — `Gladiator 23.976
 FPS` correctly yields `frame_rate: 23.976fps` because the `FPS` suffix disambiguates it.
 
-An adjacent **video codec** does disambiguate it, and is handled since #933:
+A **video codec** sitting in the same tag block does disambiguate it, and is handled since #933:
 `Les.Profs.2013.FRENCH.AC3.1080.x264-Ox` yields `screen_size: 1080p` + `video_codec: H.264`. The
-cases above have no such neighbour — `BrRip.264` is a stray number, not an `x264` codec token.
+cases above have no such neighbour — `BrRip.264` is a stray number, not an `x264` codec token. A
+codec quoted in its own group stays neutral, so an absolute episode number survives it
+(`[Group] One Piece - 1080 [x264].mkv` -> `episode: 1080`).
 
 ### #637 — a one-letter title followed by a number
 

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -232,6 +232,9 @@ def episodes(config: dict[str, Any]) -> Rebulk:
     season_max_range = config["season_max_range"]
     max_range_gap = config["max_range_gap"]
 
+    season_ep_marker_pattern = build_or_pattern(season_ep_markers, name="episodeMarker")
+    asymmetric_season_ep_marker = r"(?!@" + build_or_pattern(season_ep_markers) + r"\d)"
+
     rebulk = (
         Rebulk()
         .regex_defaults(flags=re.IGNORECASE)
@@ -293,7 +296,9 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         validator={"__parent__": and_(seps_surround, ordering_validator)},
         disabled=is_season_episode_disabled,
     ).defaults(tags=["SxxExx"]).regex(
-        r"(?P<season>\d+)@?" + build_or_pattern(season_ep_markers, name="episodeMarker") + r"@?(?P<episode>\d+)"
+        # A separator before the marker requires one after it too: "1x03" and "1 x 03" are episodes,
+        # while "1080.x264" is a number followed by a codec token (#933).
+        r"(?P<season>\d+)" + asymmetric_season_ep_marker + r"@?" + season_ep_marker_pattern + r"@?(?P<episode>\d+)"
     ).repeater("+")
 
     rebulk.chain(

--- a/guessit/rules/properties/screen_size.py
+++ b/guessit/rules/properties/screen_size.py
@@ -50,7 +50,8 @@ def screen_size(config: dict[str, Any]) -> Rebulk:
     interlaced_pattern = build_or_pattern(interlaced, name="height")
     progressive_pattern = build_or_pattern(progressive, name="height")
 
-    res_pattern = r"(?:(?P<width>\d{3,4})(?:x|\*|×))?"  # noqa: RUF001  # U+00D7 resolution separator
+    res_separator = r"(?:x|\*|×)"  # noqa: RUF001  # U+00D7 resolution separator
+    res_pattern = r"(?:(?P<width>\d{3,4})" + res_separator + r")?"
     upscaled = r"(?:up)?"  # tolerate a trailing "up" (upscaled) marker glued to the resolution (#741)
     rebulk.regex(res_pattern + interlaced_pattern + r"(?P<scan_type>i)" + frame_rate_pattern + "?")
     rebulk.regex(res_pattern + progressive_pattern + r"(?P<scan_type>p)" + frame_rate_pattern + "?")
@@ -61,8 +62,10 @@ def screen_size(config: dict[str, Any]) -> Rebulk:
         value="2160p",
         conflict_solver=lambda match, other: "__default__" if other.name == "screen_size" else match,
     )
+    # The separators around the "x" must be symmetric: "1920x1080" and "1920 x 1080" are resolutions,
+    # while a leading-only separator ("1080.x264") is a resolution followed by a codec (#933).
     rebulk.regex(
-        r"(?P<width>\d{3,4})-?(?:x|\*|×)-?(?P<height>\d{3,4})" + upscaled,  # noqa: RUF001  # U+00D7 separator
+        r"(?P<width>\d{3,4})(?:" + res_separator + r"|-" + res_separator + r"-)(?P<height>\d{3,4})" + upscaled,
         conflict_solver=lambda match, other: "__default__" if other.name == "screen_size" else other,
     )
 
@@ -174,9 +177,11 @@ class ResolveScreenSizeConflicts(Rule):
                 continue
 
             has_neighbor = False
-            video_profile = matches.range(screensize.end, filepart.end, lambda match: match.name == "video_profile", 0)
-            if video_profile and not matches.holes(
-                screensize.end, video_profile.start, predicate=lambda h: h.value and h.value.strip(seps)
+            following = matches.range(
+                screensize.end, filepart.end, lambda match: match.name in ("video_profile", "video_codec"), 0
+            )
+            if following and not matches.holes(
+                screensize.end, following.start, predicate=lambda h: h.value and h.value.strip(seps)
             ):
                 to_remove.extend(conflicts)
                 has_neighbor = True

--- a/guessit/rules/properties/screen_size.py
+++ b/guessit/rules/properties/screen_size.py
@@ -165,13 +165,23 @@ class ResolveScreenSizeConflicts(Rule):
 
     consequence = RemoveMatch
 
+    @staticmethod
+    def _same_group(matches: Matches, first: Match, second: Match) -> bool:
+        """Whether both matches sit in the same bracketed group (or both outside of any)."""
+
+        def group_of(match: Match) -> Match | None:
+            return matches.markers.at_match(match, lambda marker: marker.name == "group", 0)
+
+        return group_of(first) == group_of(second)
+
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         to_remove: list[Match] = []
         for filepart in matches.markers.named("path"):
-            screensize = matches.range(filepart.start, filepart.end, lambda match: match.name == "screen_size", 0)
-            if not screensize:
+            screensizes = matches.range(filepart.start, filepart.end, lambda match: match.name == "screen_size")
+            if not screensizes:
                 continue
 
+            screensize = screensizes[0]
             conflicts = matches.conflicting(screensize, lambda match: match.name in ("season", "episode"))
             if not conflicts:
                 continue
@@ -183,8 +193,14 @@ class ResolveScreenSizeConflicts(Rule):
             if following and not matches.holes(
                 screensize.end, following.start, predicate=lambda h: h.value and h.value.strip(seps)
             ):
-                to_remove.extend(conflicts)
-                has_neighbor = True
+                # A video_codec marks the number as a resolution ("1080.x264" -> 1080p) only when both
+                # sit in the same tag block and the part spells no other resolution: a codec quoted in
+                # its own group says nothing about the number ("One Piece - 1080 [x264]") (#933).
+                if following.name == "video_profile" or (
+                    len(screensizes) == 1 and self._same_group(matches, screensize, following)
+                ):
+                    to_remove.extend(conflicts)
+                    has_neighbor = True
 
             previous = matches.previous(
                 screensize, index=0, predicate=(lambda m: m.name in ("date", "source", "other", "streaming_service"))

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5271,3 +5271,31 @@
   screen_size: 1080p
   video_codec: H.264
   release_group: GRP
+
+# The codec only marks the number as a resolution when both sit in the same tag block: a codec
+# quoted in its own group leaves an absolute episode number alone (#933).
+? '[Group] One Piece - 1080 [1080p][x264].mkv'
+: title: One Piece
+  episode: 1080
+  screen_size: 1080p
+  video_codec: H.264
+  release_group: Group
+
+? '[Group] Show Name - 1080 [x264].mkv'
+: title: Show Name
+  episode: 1080
+  video_codec: H.264
+  -screen_size: 1080p
+
+? Show.Name.101.x264-GRP
+: title: Show Name
+  episode: 101
+  video_codec: H.264
+  release_group: GRP
+  -screen_size: 101x264
+
+? Anime - 03 x264 GRP.mkv
+: title: Anime
+  episode: 3
+  video_codec: H.264
+  -season: 3

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5256,3 +5256,18 @@
   source: Web
   video_codec: H.265
   release_group: FLTTH
+
+# #933: the "season x episode" marker tolerates separators only when they are symmetric —
+# "1 x 03" stays an episode, while a lone leading separator marks a codec token ("1080.x264").
+? Show Name 1 x 03 HDTV.avi
+: title: Show Name
+  season: 1
+  episode: 3
+  source: HDTV
+
+? Show.Name.S01.1080.x264-GRP.mkv
+: title: Show Name
+  season: 1
+  screen_size: 1080p
+  video_codec: H.264
+  release_group: GRP

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -2136,3 +2136,44 @@
 ? Alien.Director.Cut.Ita.Eng.VP9.Opus.AlphaBot.webm
 : title: Alien
   audio_codec: Opus
+
+# A "p"-less resolution followed by an x264/x265 codec: the "x" belongs to the codec, not to a
+# <width>x<height> resolution nor to a "season x episode" marker (#933).
+? Les.Profs.2013.FRENCH.AC3.1080.x264-Ox
+: title: Les Profs
+  year: 2013
+  language: French
+  audio_codec: Dolby Digital
+  screen_size: 1080p
+  video_codec: H.264
+  release_group: Ox
+  -aspect_ratio: 4.091
+  -season: 1080
+
+? Movie.Name.2013.720.x264-Ox.mkv
+: title: Movie Name
+  year: 2013
+  screen_size: 720p
+  video_codec: H.264
+  release_group: Ox
+
+? Movie.Name.2013.2160.x265-Ox.mkv
+: title: Movie Name
+  year: 2013
+  screen_size: 2160p
+  video_codec: H.265
+  release_group: Ox
+
+# Every separator flavour between the number and the codec behaves the same.
+? Movie Name 2013 1080 x265 Ox.mkv
+: title: Movie Name
+  year: 2013
+  screen_size: 1080p
+  video_codec: H.265
+
+? Movie.Name.2013.1080-x264-Ox.mkv
+: title: Movie Name
+  year: 2013
+  screen_size: 1080p
+  video_codec: H.264
+  release_group: Ox


### PR DESCRIPTION
Fixes the `1080.x264` misparse reported in #933.

## Problem

A `p`-less resolution directly followed by an `x264` / `x265` token was swallowed by the
`<width>x<height>` resolution pattern: the `x` of the codec was mistaken for the resolution
separator, the codec digits became the height, and the real `video_codec` match was dropped by the
resolution's conflict solver.

```console
$ guessit "Les.Profs.2013.FRENCH.AC3.1080.x264-Ox"
    "screen_size": "1080x264",   # wrong
    "aspect_ratio": 4.091,       # nonsensical
    # video_codec: gone
```

## Fix

**1. Symmetric separators around the `x`.** Both patterns that read an `x` between two numbers now
require the separators around it to be symmetric:

- `screen_size` — `(?P<width>\d{3,4})(?:x|-x-)(?P<height>\d{3,4})`
- `episodes` (the `season x episode` chain) — a lookahead rejects `<digits><sep>x<digit>`

`1920x1080` and `1920 x 1080` stay resolutions, `1x03` and `1 x 03` stay episodes, while a
leading-only separator (`1080.x264`, `5.1.x264`) marks a codec token.

**2. A neighbouring codec as a resolution marker.** That alone leaves the bare `1080` to the
season/episode fallback, so `ResolveScreenSizeConflicts` also accepts a following `video_codec` as
a disambiguating marker, on a par with the `video_profile` it already looked for — but only when
both sit in the **same tag block** and the part spells **no other resolution**. A codec quoted in
its own group says nothing about a neighbouring number, so anime absolute episode numbers survive
(`[Group] One Piece - 1080 [1080p][x264].mkv` → `episode: 1080`).

Result:

```console
$ guessit "Les.Profs.2013.FRENCH.AC3.1080.x264-Ox"
    "screen_size": "1080p",
    "video_codec": "H.264",
```

## Behaviour changes

Diffed against `develop` over a set of hand-picked cases — every difference is an improvement:

| Input | Before | After |
| --- | --- | --- |
| `Les.Profs.2013.FRENCH.AC3.1080.x264-Ox` | `1080x264`, `aspect_ratio: 4.091`, no codec | `1080p` + `H.264` |
| `Show.Name.720.x264-GRP` | `720x264`, `aspect_ratio: 2.727`, no codec | `720p` + `H.264` |
| `Show.Name.S01E02.720.x264-GRP` | `720x264`, `aspect_ratio: 2.727`, no codec | `720p` + `H.264` |
| `Show.Name.101.x264-GRP` | `screen_size: 101x264`, `aspect_ratio: 0.383` | `episode: 101` + `H.264` |
| `Anime - 03 x264 GRP.mkv` | `season: 3` | `episode: 3` |
| `Show.Name.1080.h264-GRP` | `season: 10`, `episode: 80` | `1080p` + `H.264` |

The last row is a partial improvement on #693 (closed *won't fix*): the bare-number cases there
(`Gladiator.EXTENDED.2000.1080.BrRip.264.YIFY`, `Aliens DVD Silver Box Set 131 Min`) have no
adjacent codec token and are **unchanged**. `docs/known-limitations.md` records that an adjacent
codec now counts as a marker, and that a codec in its own group stays neutral.

Anime releases keep their absolute episode numbers unchanged:
`[Group] One Piece - 1080 [1080p][x264].mkv`, `[Group] Show - 1080 [x264].mkv`,
`One Piece - 720 [x264].mkv`.

## Tests

- 11 new corpus entries (5 in `movies.yml`, 6 in `episodes.yml`): the reported case, each separator
  flavour, the symmetric forms that must keep working (`1 x 03`, `S01.1080.x264`), and the anime
  quoted-codec cases that must keep their episode number.
- Full suite green: **2370 passed**, 4 skipped.
- Cross-parser suite green: **5 passed** — no new divergence against the external parsers.
- `ruff check` / `ruff format` / `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
