### PR TITLE
fix(episodes): apply the codec-token guard to both season-x-episode chains

### DIFF
--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -307,7 +307,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         validator={"__parent__": and_(seps_surround, ordering_validator)},
         disabled=is_season_episode_disabled,
     ).defaults(tags=["SxxExx"]).regex(
-        r"(?P<season>\d+)@?" + build_or_pattern(season_ep_markers, name="episodeMarker") + r"@?(?P<episode>\d+)"
+        r"(?P<season>\d+)" + asymmetric_season_ep_marker + r"@?" + season_ep_marker_pattern + r"@?(?P<episode>\d+)"
     ).regex(
         build_or_pattern(
             season_ep_markers + discrete_separators + range_separators, name="episodeSeparator", escape=True

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5287,12 +5287,21 @@
   video_codec: H.264
   -screen_size: 1080p
 
+# "101" reads as S01E01 whatever the codec spelling follows it — "x264" now behaves like "h264".
 ? Show.Name.101.x264-GRP
 : title: Show Name
-  episode: 101
+  season: 1
+  episode: 1
   video_codec: H.264
   release_group: GRP
   -screen_size: 101x264
+
+? Show.Name.101.h264-GRP
+: title: Show Name
+  season: 1
+  episode: 1
+  video_codec: H.264
+  release_group: GRP
 
 ? Anime - 03 x264 GRP.mkv
 : title: Anime

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -2177,3 +2177,22 @@
   screen_size: 1080p
   video_codec: H.264
   release_group: Ox
+
+# The same release with the type forced: the number keeps its resolution reading even when the
+# weak-episode patterns are off, so no orphan season is left behind (#937).
+? Les.Profs.2013.FRENCH.AC3.1080.x264-Ox
+: options: --type movie
+  title: Les Profs
+  year: 2013
+  screen_size: 1080p
+  video_codec: H.264
+  release_group: Ox
+  -season: 1080
+
+? Movie.Name.2013.720.x264-Ox.mkv
+: options: --type movie
+  title: Movie Name
+  year: 2013
+  screen_size: 720p
+  video_codec: H.264
+  -season: 720


### PR DESCRIPTION
Fixes #937 — the follow-up hole left by #934.

## Problem

`episodes.py` declares **two** near-identical `season x episode` chains: the plain one, and a
second that adds a repeated `episodeSeparator` group for episode lists (`1x02x03`). #934 added the
asymmetric-separator lookahead to the first chain only, so the second still matched
`1080` `.` `x264` as `season=1080, episode=264`.

The default mode hid it: the competing `weak-episode` patterns cover the same span and
`ResolveScreenSizeConflicts` arbitrates in favour of the resolution. Those chains are **disabled
when the type is forced to `movie`** (`episodes.py:441,449,458`), so nothing opposed the bogus
season; its episode `264` was then dropped as out of range, leaving an orphan `season: 1080` that
outranks the `screen_size` candidate at conflict-solving time.

```console
$ guessit --type movie "Les.Profs.2013.FRENCH.AC3.1080.x264-Ox"   # v4.2.0
    "season": 1080,      # wrong, and a season on a movie
    # screen_size: gone
```

## Fix

Both chains now share the same `asymmetric_season_ep_marker` guard — a one-line change.

```console
$ guessit --type movie "Les.Profs.2013.FRENCH.AC3.1080.x264-Ox"   # this PR
    "screen_size": "1080p",
    "video_codec": "H.264",
```

## Regression check

The corpus barely exercises a forced `type`, which is exactly why this slipped through. So beyond
the test suite, every name in `movies.yml` + `episodes.yml` + `various.yml` (996 names) was parsed
under **both** `type=movie` and `type=episode` and diffed against v4.2.0: **9 differences out of
1992**, all improvements, none on a historical corpus name.

| Case (forced type) | v4.2.0 | This PR |
| --- | --- | --- |
| `…AC3.1080.x264-Ox` (movie) | `season: 1080`, no resolution | `screen_size: 1080p` |
| `…2160.x265-Ox.mkv` (movie) | `season: 2160` | `screen_size: 2160p` |
| `Show.Name.S01.1080.x264-GRP.mkv` (movie) | `season: [1, 1080]` | `season: 1` + `1080p` |
| `Show.Name.101.x264-GRP` (episode) | `episode: 101` | `season: 1, episode: 1` |

The last row is a deliberate alignment: `101` reads as `S01E01` everywhere else, including
`101.h264` on v4.1.0 — `x264` now behaves like `h264` instead of being swallowed. The corpus entry
added in #934 captured the intermediate artefact and is updated accordingly, with an `h264` twin
added next to it.

## Tests

- 2 new corpus entries using `options: --type movie`, so the forced-type path is covered from now on.
- Full suite green: **2371 passed**, 4 skipped — also green under the `regex` module
  (`REBULK_REGEX_ENABLED=1`).
- Cross-parser suite green: **5 passed**.
- `ruff check` / `ruff format` / `mypy --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
