### PR TITLE
fix(episodes): keep a year anchoring the title when the type is forced

### DIFF
--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -543,7 +543,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         SeePatternRange([*range_separators, "_"]),
         EpisodeNumberSeparatorRange(range_separators),
         SeasonSeparatorRange(range_separators),
-        RemoveWeakIfMovie,
+        RemoveWeakIfMovie(episode_words),
         RemoveWeakIfSxxExx,
         RemoveWeakDuplicate,
         EpisodeDetailValidator,
@@ -960,13 +960,33 @@ class SeasonSeparatorRange(AbstractSeparatorRange):
 class RemoveWeakIfMovie(Rule):
     """
     Remove weak-episode tagged matches if it seems to be a movie.
+
+    A year in the part is a movie signal strong enough to drop the weak readings, whatever the
+    requested type: forcing `type=episode` must not turn the leading number of a title into an
+    episode ("12.Angry.Men.1957" stays "12 Angry Men" + year 1957). Weak matches carrying an
+    explicit marker ("Episodio 13") are numbered on purpose and stay (#939).
     """
 
     priority = 64
     consequence = RemoveMatch
 
-    def enabled(self, context: dict[str, Any] | None) -> bool:
-        return bool(context and context.get("type") != "episode")
+    def __init__(self, episode_words: list[str]) -> None:
+        super().__init__()
+        self.episode_words = episode_words
+
+    def _is_numbered_on_purpose(self, matches: Matches, match: Match) -> bool:
+        """Whether the number carries an explicit marker ("Episodio 13", "S01E02")."""
+        initiator = match.initiator
+        if initiator is not None and (
+            initiator.children.named("episodeMarker") or initiator.children.named("seasonMarker")
+        ):
+            return True
+
+        preceding = matches.holes(0, match.start, predicate=lambda h: (h.raw or "").strip(seps))
+        if not preceding:
+            return False
+        words = re.split(rf"[{re.escape(seps)}]+", (preceding[-1].raw or "").strip(seps))
+        return bool(words) and words[-1].lower() in self.episode_words
 
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         to_remove: list[Match] = []
@@ -994,7 +1014,14 @@ class RemoveWeakIfMovie(Rule):
         if remove:
             to_remove.extend(
                 matches.tagged(
-                    "weak-episode", predicate=(lambda m: m.initiator not in to_ignore and "anime" not in m.tags)
+                    "weak-episode",
+                    predicate=(
+                        lambda m: (
+                            m.initiator not in to_ignore
+                            and "anime" not in m.tags
+                            and not self._is_numbered_on_purpose(matches, m)
+                        )
+                    ),
                 )
             )
 

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -44,6 +44,8 @@ _CJK_DIGITS = {
     "九": 9,
 }
 
+_SEPS_RE = re.compile(rf"[{re.escape(seps)}]+")
+
 # ASCII digits or Han numerals up to 99 (十一 -> 11, 二十三 -> 23, single digit otherwise).
 cjk_number = r"(?:\d{1,4}|[一二两三四五六七八九]?十[一二两三四五六七八九]?|[零一二两三四五六七八九])"
 
@@ -982,11 +984,14 @@ class RemoveWeakIfMovie(Rule):
         ):
             return True
 
-        preceding = matches.holes(0, match.start, predicate=lambda h: (h.raw or "").strip(seps))
+        # The word must sit in the same filepart: a parent directory named "Episode" says nothing
+        # about a number in the filename below it.
+        filepart = matches.markers.at_match(match, lambda marker: marker.name == "path", 0)
+        start = filepart.start if filepart else 0
+        preceding = (match.input_string or "")[start : match.start].strip(seps)
         if not preceding:
             return False
-        words = re.split(rf"[{re.escape(seps)}]+", (preceding[-1].raw or "").strip(seps))
-        return bool(words) and words[-1].lower() in self.episode_words
+        return _SEPS_RE.split(preceding)[-1].lower() in self.episode_words
 
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         to_remove: list[Match] = []

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -93,3 +93,10 @@ def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict
     result = guessit(name, {"type": "episode"})
     for prop, value in expected.items():
         assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
+
+
+def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
+    """A parent directory named "Episode" must not vouch for a number in the file below it."""
+    result = guessit("Series/Episode/12.Angry.Men.1957.mkv", {"type": "episode"})
+    assert result.get("title") == "12 Angry Men"
+    assert result.get("year") == 1957

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+"""Consistency of the forced ``type`` modes (#939).
+
+Forcing the type guessit already infers must be a no-op: ``guessit(name, {"type": t})`` has to
+return exactly ``guessit(name)`` whenever the latter yields ``type: t``. The whole yaml corpus is
+swept, so any new divergence shows up here even though the corpus itself barely exercises the
+forced modes.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import yaml
+
+from .. import guessit
+from ..yamlutils import OrderedDictYAMLLoader
+from . import test_yml
+
+__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+
+# Names whose forced-type result still differs from the inferred one. Each is a lone digit that
+# only the forced-episode patterns pick up — inside a release group, a path segment or a duplicate
+# marker — and pushes out a property. Tracked by #939; entries must be removed as they get fixed.
+KNOWN_DIVERGENCES = frozenset(
+    {
+        "series/Freaks And Geeks/Season 1/Episode 4 - Kim Kelly Is My Friend-eng(1).srt",
+        "/Volumes/data-1/Series/Futurama/Season 3/Futurama_-_S03_DVD_Bonus_-_Deleted_Scenes_Part_3.ogm",
+        "[t.3.3.d]_Mikakunin_de_Shinkoukei_-_12_[720p][5DDC1352].mkv",
+        "[7.1.7.8.5] Foo Bar - 11 (H.264) [5235532D].mkv",
+        "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]",
+        "Thumping.Spike.2.E01.DF.WEBRip.720p-DRAMATV.mp4",
+        "La Casa di Carta Stagione 2 Episodio 5",
+        "GTTV.E3.All.Access.Live.Day.1.Xbox.Showcase.Preshow.HDTV.x264-SYS",
+    }
+)
+
+
+def corpus_names() -> list[str]:
+    """Every input string of the yaml corpus, minus the entries pinned to their own options."""
+    names: list[str] = []
+    for filename, _ in zip(*test_yml.files_and_ids(), strict=False):
+        with open(os.path.join(__location__, filename), encoding="utf-8") as infile:
+            data = yaml.load(infile, OrderedDictYAMLLoader)
+        for string, expected in data.items():
+            if string == "__default__" or (isinstance(expected, dict) and "options" in expected):
+                continue
+            match = test_yml.TestYml.options_re.match(str(string))
+            name = match.group(2) if match else str(string)
+            if name:
+                names.append(test_yml.TestYml.fix_encoding(name))
+    return sorted(set(names))
+
+
+def test_forcing_the_inferred_type_is_a_no_op() -> None:
+    names = corpus_names()
+    divergences = {}
+    for name in names:
+        inferred = guessit(name)
+        guessed_type = inferred.get("type")
+        if guessed_type not in ("movie", "episode"):
+            continue
+        forced = guessit(name, {"type": guessed_type})
+        if dict(forced) != dict(inferred):
+            divergences[name] = (dict(inferred), dict(forced))
+
+    unexpected = {name: diff for name, diff in divergences.items() if name not in KNOWN_DIVERGENCES}
+    assert not unexpected, "forcing the inferred type changed the result:\n" + "\n".join(
+        f"  {name}\n    inferred={inferred}\n    forced  ={forced}" for name, (inferred, forced) in unexpected.items()
+    )
+
+    scanned = set(names)
+    stale = {name for name in KNOWN_DIVERGENCES if name in scanned and name not in divergences}
+    assert not stale, f"these names no longer diverge, drop them from KNOWN_DIVERGENCES: {sorted(stale)}"
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # A year in the part keeps the leading number of the title out of the episode reading,
+        # whatever the requested type (#939).
+        ("12.Angry.Men.1957.mkv", {"title": "12 Angry Men", "year": 1957}),
+        ("Movies/21 (2008)/21.(2008).DVDRip.x264.AC3-FtS.mkv", {"title": "21", "year": 2008, "release_group": "FtS"}),
+        # An explicit episode marker is still numbered, year or not.
+        (
+            "Mastercook Italia - Stagione 6 (2016) 720p Episodio 13 spyro.mkv",
+            {"season": 6, "episode": 13, "year": 2016},
+        ),
+    ],
+)
+def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict[str, object]) -> None:
+    result = guessit(name, {"type": "episode"})
+    for prop, value in expected.items():
+        assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"


### PR DESCRIPTION
First batch for #939 — the clear defects of the forced-type audit, plus the safety net.

## What changes

`RemoveWeakIfMovie` drops the weak episode readings when a **year** is present in the part, but it
was disabled as soon as `type=episode` was requested. That single `enabled()` guard is behind most
of the audit's findings: forcing the episode type turned the leading number of a title into an
episode and lost the year.

```console
$ guessit --type episode "12.Angry.Men.1957.mkv"
  before → episode: 12, title: "Angry Men"          (year gone)
  after  → title: "12 Angry Men", year: 1957

$ guessit --type episode "…/21.(2008).DVDRip.x264.AC3-FtS.…mkv"
  before → episode: 21, season: 2008, title: "FtS"  (release group became the title)
  after  → title: "21", year: 2008, release_group: "FtS"
```

The rule now applies **whatever the requested type**, and spares the weak matches that are
*numbered on purpose* — either through a `season`/`episode` marker child, or through an episode
word sitting right before the number, read from the configured `episode_words`. That second
condition is what keeps `Mastercook Italia - Stagione 6 (2016) 720p Episodio 13 spyro.mkv` at
`episode: 13`: an explicit `Episodio` marker is a deliberate number, a bare `12` in front of a
title is not.

This implements the product decision recorded on the issue (*"forbid it when a year is present"*)
— it turned out to be the same one-line guard as the defects, so splitting it across two PRs would
have meant writing it twice.

## Measured on the whole corpus (996 names × 3 modes)

| | before | after |
| --- | --- | --- |
| forcing the inferred type changes the result | 9 names | **7** |
| `year` lost under `--type episode` | 3 | **0** |
| `release_group` lost under `--type episode` | 3 | **2** |
| `season` equal to a `year` under `--type episode` | 24 | **17** |
| inferred mode (no `type` option) | — | **byte-identical, 0 names changed** |

## Safety net (finding 6 of the audit)

`test_forced_type.py` sweeps every corpus name and asserts the invariant **`guessit(name, {"type":
t}) == guessit(name)` whenever `guessit(name)["type"] == t`**. It is what the corpus was missing:
~1% of its entries pin a `--type`, which is why #937 shipped in v4.2.0 unnoticed.

The 8 divergences that remain (the sweep is wider than the manual audit and found one more,
`GTTV.E3.All.Access.Live.Day.1…`) are listed in `KNOWN_DIVERGENCES` with their shared cause: a lone
digit that only the forced-episode patterns pick up — inside a release group (`[7.1.7.8.5]`), a
path segment (`/Volumes/data-1/…`), or a duplicate marker (`(1).srt`). The test fails both on a
**new** divergence and on a **stale** entry, so the list cannot rot.

## Not in this PR

- **Those 8 remaining divergences.** They need the lone-digit pattern to be narrowed without
  breaking legitimate episode lists — the obvious widening of `RemoveWeakIfSxxExx` was tried and
  breaks `Some Series E01 02 03` and `Show.Name.Season.4.Episodes.1-12`, so it deserves its own
  work.
- **Finding 5** (`--type movie` losing `other: Complete` on 3 names and `release_group` on 2). It
  is structural rather than an isolated bug: with the weak-episode chains disabled under
  `type=movie`, `Bleach.s16e03-04.313-314-GROUP` has no second episode group to rename into
  `absolute_episode`, so `313-314-GROUP` collapses into an `alternative_title` that swallows the
  release group. Fixing it means making release-group detection independent of episode parsing.

## Tests

- Full suite green: **2375 passed**, 4 skipped — also under the `regex` module.
- Cross-parser green: **5 passed**.
- `ruff` / `mypy --strict` clean.

Refs #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)
