### PR TITLE
chore(release): v4.2.1

### DIFF
--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -307,7 +307,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         validator={"__parent__": and_(seps_surround, ordering_validator)},
         disabled=is_season_episode_disabled,
     ).defaults(tags=["SxxExx"]).regex(
-        r"(?P<season>\d+)@?" + build_or_pattern(season_ep_markers, name="episodeMarker") + r"@?(?P<episode>\d+)"
+        r"(?P<season>\d+)" + asymmetric_season_ep_marker + r"@?" + season_ep_marker_pattern + r"@?(?P<episode>\d+)"
     ).regex(
         build_or_pattern(
             season_ep_markers + discrete_separators + range_separators, name="episodeSeparator", escape=True

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -44,6 +44,8 @@ _CJK_DIGITS = {
     "九": 9,
 }
 
+_SEPS_RE = re.compile(rf"[{re.escape(seps)}]+")
+
 # ASCII digits or Han numerals up to 99 (十一 -> 11, 二十三 -> 23, single digit otherwise).
 cjk_number = r"(?:\d{1,4}|[一二两三四五六七八九]?十[一二两三四五六七八九]?|[零一二两三四五六七八九])"
 
@@ -543,7 +545,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         SeePatternRange([*range_separators, "_"]),
         EpisodeNumberSeparatorRange(range_separators),
         SeasonSeparatorRange(range_separators),
-        RemoveWeakIfMovie,
+        RemoveWeakIfMovie(episode_words),
         RemoveWeakIfSxxExx,
         RemoveWeakDuplicate,
         EpisodeDetailValidator,
@@ -960,13 +962,36 @@ class SeasonSeparatorRange(AbstractSeparatorRange):
 class RemoveWeakIfMovie(Rule):
     """
     Remove weak-episode tagged matches if it seems to be a movie.
+
+    A year in the part is a movie signal strong enough to drop the weak readings, whatever the
+    requested type: forcing `type=episode` must not turn the leading number of a title into an
+    episode ("12.Angry.Men.1957" stays "12 Angry Men" + year 1957). Weak matches carrying an
+    explicit marker ("Episodio 13") are numbered on purpose and stay (#939).
     """
 
     priority = 64
     consequence = RemoveMatch
 
-    def enabled(self, context: dict[str, Any] | None) -> bool:
-        return bool(context and context.get("type") != "episode")
+    def __init__(self, episode_words: list[str]) -> None:
+        super().__init__()
+        self.episode_words = episode_words
+
+    def _is_numbered_on_purpose(self, matches: Matches, match: Match) -> bool:
+        """Whether the number carries an explicit marker ("Episodio 13", "S01E02")."""
+        initiator = match.initiator
+        if initiator is not None and (
+            initiator.children.named("episodeMarker") or initiator.children.named("seasonMarker")
+        ):
+            return True
+
+        # The word must sit in the same filepart: a parent directory named "Episode" says nothing
+        # about a number in the filename below it.
+        filepart = matches.markers.at_match(match, lambda marker: marker.name == "path", 0)
+        start = filepart.start if filepart else 0
+        preceding = (match.input_string or "")[start : match.start].strip(seps)
+        if not preceding:
+            return False
+        return _SEPS_RE.split(preceding)[-1].lower() in self.episode_words
 
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         to_remove: list[Match] = []
@@ -994,7 +1019,14 @@ class RemoveWeakIfMovie(Rule):
         if remove:
             to_remove.extend(
                 matches.tagged(
-                    "weak-episode", predicate=(lambda m: m.initiator not in to_ignore and "anime" not in m.tags)
+                    "weak-episode",
+                    predicate=(
+                        lambda m: (
+                            m.initiator not in to_ignore
+                            and "anime" not in m.tags
+                            and not self._is_numbered_on_purpose(matches, m)
+                        )
+                    ),
                 )
             )
 

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5287,12 +5287,21 @@
   video_codec: H.264
   -screen_size: 1080p
 
+# "101" reads as S01E01 whatever the codec spelling follows it — "x264" now behaves like "h264".
 ? Show.Name.101.x264-GRP
 : title: Show Name
-  episode: 101
+  season: 1
+  episode: 1
   video_codec: H.264
   release_group: GRP
   -screen_size: 101x264
+
+? Show.Name.101.h264-GRP
+: title: Show Name
+  season: 1
+  episode: 1
+  video_codec: H.264
+  release_group: GRP
 
 ? Anime - 03 x264 GRP.mkv
 : title: Anime

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -2177,3 +2177,22 @@
   screen_size: 1080p
   video_codec: H.264
   release_group: Ox
+
+# The same release with the type forced: the number keeps its resolution reading even when the
+# weak-episode patterns are off, so no orphan season is left behind (#937).
+? Les.Profs.2013.FRENCH.AC3.1080.x264-Ox
+: options: --type movie
+  title: Les Profs
+  year: 2013
+  screen_size: 1080p
+  video_codec: H.264
+  release_group: Ox
+  -season: 1080
+
+? Movie.Name.2013.720.x264-Ox.mkv
+: options: --type movie
+  title: Movie Name
+  year: 2013
+  screen_size: 720p
+  video_codec: H.264
+  -season: 720

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""Consistency of the forced ``type`` modes (#939).
+
+Forcing the type guessit already infers must be a no-op: ``guessit(name, {"type": t})`` has to
+return exactly ``guessit(name)`` whenever the latter yields ``type: t``. The whole yaml corpus is
+swept, so any new divergence shows up here even though the corpus itself barely exercises the
+forced modes.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import yaml
+
+from .. import guessit
+from ..yamlutils import OrderedDictYAMLLoader
+from . import test_yml
+
+__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+
+# Names whose forced-type result still differs from the inferred one. Each is a lone digit that
+# only the forced-episode patterns pick up — inside a release group, a path segment or a duplicate
+# marker — and pushes out a property. Tracked by #939; entries must be removed as they get fixed.
+KNOWN_DIVERGENCES = frozenset(
+    {
+        "series/Freaks And Geeks/Season 1/Episode 4 - Kim Kelly Is My Friend-eng(1).srt",
+        "/Volumes/data-1/Series/Futurama/Season 3/Futurama_-_S03_DVD_Bonus_-_Deleted_Scenes_Part_3.ogm",
+        "[t.3.3.d]_Mikakunin_de_Shinkoukei_-_12_[720p][5DDC1352].mkv",
+        "[7.1.7.8.5] Foo Bar - 11 (H.264) [5235532D].mkv",
+        "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]",
+        "Thumping.Spike.2.E01.DF.WEBRip.720p-DRAMATV.mp4",
+        "La Casa di Carta Stagione 2 Episodio 5",
+        "GTTV.E3.All.Access.Live.Day.1.Xbox.Showcase.Preshow.HDTV.x264-SYS",
+    }
+)
+
+
+def corpus_names() -> list[str]:
+    """Every input string of the yaml corpus, minus the entries pinned to their own options."""
+    names: list[str] = []
+    for filename, _ in zip(*test_yml.files_and_ids(), strict=False):
+        with open(os.path.join(__location__, filename), encoding="utf-8") as infile:
+            data = yaml.load(infile, OrderedDictYAMLLoader)
+        for string, expected in data.items():
+            if string == "__default__" or (isinstance(expected, dict) and "options" in expected):
+                continue
+            match = test_yml.TestYml.options_re.match(str(string))
+            name = match.group(2) if match else str(string)
+            if name:
+                names.append(test_yml.TestYml.fix_encoding(name))
+    return sorted(set(names))
+
+
+def test_forcing_the_inferred_type_is_a_no_op() -> None:
+    names = corpus_names()
+    divergences = {}
+    for name in names:
+        inferred = guessit(name)
+        guessed_type = inferred.get("type")
+        if guessed_type not in ("movie", "episode"):
+            continue
+        forced = guessit(name, {"type": guessed_type})
+        if dict(forced) != dict(inferred):
+            divergences[name] = (dict(inferred), dict(forced))
+
+    unexpected = {name: diff for name, diff in divergences.items() if name not in KNOWN_DIVERGENCES}
+    assert not unexpected, "forcing the inferred type changed the result:\n" + "\n".join(
+        f"  {name}\n    inferred={inferred}\n    forced  ={forced}" for name, (inferred, forced) in unexpected.items()
+    )
+
+    scanned = set(names)
+    stale = {name for name in KNOWN_DIVERGENCES if name in scanned and name not in divergences}
+    assert not stale, f"these names no longer diverge, drop them from KNOWN_DIVERGENCES: {sorted(stale)}"
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # A year in the part keeps the leading number of the title out of the episode reading,
+        # whatever the requested type (#939).
+        ("12.Angry.Men.1957.mkv", {"title": "12 Angry Men", "year": 1957}),
+        ("Movies/21 (2008)/21.(2008).DVDRip.x264.AC3-FtS.mkv", {"title": "21", "year": 2008, "release_group": "FtS"}),
+        # An explicit episode marker is still numbered, year or not.
+        (
+            "Mastercook Italia - Stagione 6 (2016) 720p Episodio 13 spyro.mkv",
+            {"season": 6, "episode": 13, "year": 2016},
+        ),
+    ],
+)
+def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict[str, object]) -> None:
+    result = guessit(name, {"type": "episode"})
+    for prop, value in expected.items():
+        assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
+
+
+def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
+    """A parent directory named "Episode" must not vouch for a number in the file below it."""
+    result = guessit("Series/Episode/12.Angry.Men.1957.mkv", {"type": "episode"})
+    assert result.get("title") == "12 Angry Men"
+    assert result.get("year") == 1957


### PR DESCRIPTION
Release **v4.2.1** (computed by python-semantic-release: 2 `fix`, no breaking change).

## Fixes

- **#937** — a `p`-less resolution followed by `x264`/`x265` still misparsed when the type was
  forced: `guessit --type movie "Les.Profs.2013.FRENCH.AC3.1080.x264-Ox"` returned `season: 1080`
  instead of `screen_size: 1080p`. The codec-token guard added in #934 covered only one of the two
  near-identical `season x episode` chains; both now share it. **This is the bug shipped in
  v4.2.0** — the reason for this release.
- **#939 (partial)** — forcing `type=episode` no longer sacrifices a year to an episode number:
  `12.Angry.Men.1957.mkv` keeps `title: "12 Angry Men"` + `year: 1957`, and
  `21.(2008)…-FtS` keeps its `release_group` instead of promoting it to the title. Numbers carried
  by an explicit marker (`Episodio 13`, `S01E02`) are untouched.

## Tests

`test_forced_type.py` now sweeps the whole corpus asserting that forcing the type guessit already
infers is a no-op — the coverage gap that let #937 ship unnoticed. Remaining known divergences are
listed there and tracked by #939.

---

⚠️ Merge as a **merge commit**, never squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
