### PR TITLE
fix(title): keep the title when alternative_title is excluded

### DIFF
--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -317,8 +317,8 @@ class TitleBaseRule(Rule):
 
             if hole and hole.value:
                 hole.name = self.match_name
-                hole.tags = self.match_tags or []
-                if self.alternative_match_name:
+                hole.tags = list(self.match_tags or [])
+                if self.alternative_match_name and not is_disabled(context, self.alternative_match_name):
                     # Split and keep values that can be a title
                     titles = hole.split(title_seps, lambda m: m.value)
                     for title_match in list(titles[1:]):
@@ -451,9 +451,6 @@ class TitleFromPosition(TitleBaseRule):
 
     def __init__(self) -> None:
         super().__init__("title", ["title"], "alternative_title")
-
-    def enabled(self, context: dict[str, Any] | None) -> bool:
-        return not is_disabled(context, "alternative_title")
 
 
 class PreferTitleWithYear(Rule):

--- a/guessit/test/enable_disable_properties.yml
+++ b/guessit/test/enable_disable_properties.yml
@@ -254,6 +254,11 @@
 : options: --exclude title
   -title: Title Only
 
+? Star Wars - The Mandalorian and Grogu (2026) 720p x265.mkv
+: options: --exclude alternative_title
+  title: Star Wars - The Mandalorian and Grogu
+  -alternative_title: The Mandalorian and Grogu
+
 ? h265
 ? x265
 ? h.265

--- a/guessit/test/enable_disable_properties.yml
+++ b/guessit/test/enable_disable_properties.yml
@@ -259,6 +259,10 @@
   title: Star Wars - The Mandalorian and Grogu
   -alternative_title: The Mandalorian and Grogu
 
+? Some.Movie.2019.1080p.BluRay.x264-GRP.mkv
+: options: --include title
+  title: Some Movie 2019 1080p BluRay x264-GRP mkv
+
 ? h265
 ? x265
 ? h.265

--- a/guessit/test/test_api.py
+++ b/guessit/test/test_api.py
@@ -97,6 +97,34 @@ def test_list_value_not_mutated_between_guesses() -> None:
     assert guessit("ultimate collector edition")["edition"] == ["Ultimate", "Collector"]
 
 
+def test_title_rule_tags_not_mutated_between_guesses() -> None:
+    """
+    The tags TitleFromPosition puts on the title hole must be a copy of the rule's own list.
+
+    The rule instance lives in the cached rebulk and is shared by every guessit() call. When the
+    hole aliases ``match_tags`` instead of copying it, ``PreferTitleWithYear`` (which appends
+    ``equivalent-ignore`` to the title matches it demotes) extends that shared list in place, so
+    it grows at every parse and every later title is born already tagged ``equivalent-ignore`` --
+    a tag the processors act upon. A yaml corpus entry cannot catch this: each entry parses a
+    single string, while the leak only shows up on the parses that follow.
+    """
+    from ..rules.properties.title import TitleFromPosition
+
+    api.reset()
+    options = {"excludes": ["alternative_title"]}
+    for _ in range(3):
+        assert guessit("Movies/Foo (2019)/Foo.2019.1080p.BluRay.x264-GRP.mkv", options)["title"] == "Foo"
+
+    assert default_api.rebulk is not None
+    title_rule = next(
+        rule
+        for rule in default_api.rebulk.effective_rules(default_api.effective_options)
+        if isinstance(rule, TitleFromPosition)
+    )
+    assert title_rule.match_tags == ["title"]
+    api.reset()
+
+
 def test_exception() -> None:
     with pytest.raises(GuessitException) as excinfo:
         guessit(object())  # type: ignore[arg-type]


### PR DESCRIPTION
closes #927

`--excludes alternative_title` disabled `TitleFromPosition` outright, so guessit returned no `title` at all for any filename. The exclusion now only skips the alternative-title split, and the whole title hole is kept as `title` (`Star Wars - The Mandalorian and Grogu`).

While fixing it I also had to copy `match_tags` when tagging the hole rather than aliasing the rule's own list — the split path had been hiding that, and without the copy the shared list accumulated tags across parses and corrupted a later unrelated filename.

Regression case added to `enable_disable_properties.yml`; it fails on develop and passes with the fix, and the full suite is green.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
