### PR TITLE
test: track the remaining forced-type divergences in #943

### DIFF
--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -22,7 +22,7 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 # Names whose forced-type result still differs from the inferred one. Each is a lone digit that
 # only the forced-episode patterns pick up — inside a release group, a path segment or a duplicate
-# marker — and pushes out a property. Tracked by #939; entries must be removed as they get fixed.
+# marker — and pushes out a property. Tracked by #943; entries must be removed as they get fixed.
 KNOWN_DIVERGENCES = frozenset(
     {
         "series/Freaks And Geeks/Season 1/Episode 4 - Kim Kelly Is My Friend-eng(1).srt",


### PR DESCRIPTION
Follow-up to closing #939: the `KNOWN_DIVERGENCES` list in `test_forced_type.py` is the live inventory of the remaining idempotence divergences, so it points at #943 instead of the closed audit issue.

The two other `#939` references in the code are historical — they document where the behaviour comes from, like the `#741`/`#933` references elsewhere — and stay as they are.

No behaviour change, comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)