### PR TITLE
fix(episodes): drop a lone digit that plainly numbers something else

### DIFF
--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -546,6 +546,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         EpisodeNumberSeparatorRange(range_separators),
         SeasonSeparatorRange(range_separators),
         RemoveWeakIfMovie(episode_words),
+        RemoveMisleadingLoneDigitEpisode,
         RemoveWeakIfSxxExx,
         RemoveWeakDuplicate,
         EpisodeDetailValidator,
@@ -1088,6 +1089,75 @@ class RemoveWeak(Rule):
         if to_remove or to_append:
             return to_remove, to_append
         return False
+
+
+class RemoveMisleadingLoneDigitEpisode(Rule):
+    """
+    Remove a lone digit read as an episode while it plainly numbers something else.
+
+    Only a forced `type=episode` reads a single digit as an episode, and that pattern fires
+    wherever a digit sits — including inside a release group, in a parent directory, or in the
+    tail of a title — where it then evicts whatever owned that span. Such a digit is discarded
+    when it cannot be part of the episode numbering: quoted in a bracketed group, sitting in a
+    non-final path part, or unable to extend a marked episode list (a list grows rightwards from
+    its marker and stays glued to it, as in "E01 02 03") (#943).
+
+    Runs before anything is carved out of the name (rebulk executes rules by decreasing priority),
+    so the freed span goes back to the title instead of leaving a hole behind.
+    """
+
+    priority = PRE_PROCESS + 1
+    consequence = RemoveMatch
+
+    def enabled(self, context: dict[str, Any] | None) -> bool:
+        return bool(context and context.get("type") == "episode")
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        to_remove: list[Match] = []
+        fileparts = matches.markers.named("path")
+        for index, filepart in enumerate(fileparts):
+            episodes_ = sorted(
+                matches.range(filepart.start, filepart.end, predicate=lambda m: m.name == "episode"),
+                key=lambda m: (m.start, m.end),
+            )
+            # A lone digit in a parent directory numbers the directory, not the file below it
+            # ("/Volumes/data-1/Series/…"), and one quoted in a bracketed group belongs to that
+            # group's own identifier ("[7.1.7.8.5]", "[t.3.3.d]").
+            is_final_part = index == len(fileparts) - 1
+            for episode in episodes_:
+                if "weak-episode" in episode.tags and len(episode.raw or "") == 1:
+                    quoted = matches.markers.at_match(episode, lambda marker: marker.name == "group", 0)
+                    if not is_final_part or quoted:
+                        to_remove.extend(self._whole_match(matches, episode))
+
+            anchor = next((match for match in episodes_ if "weak-episode" not in match.tags), None)
+            if anchor is None:
+                continue
+
+            previous = anchor
+            for episode in episodes_:
+                lone_digit = "weak-episode" in episode.tags and len(episode.raw or "") == 1
+                if episode.end <= anchor.start:
+                    if lone_digit:
+                        to_remove.extend(self._whole_match(matches, episode))
+                    continue
+
+                between = (episode.input_string or "")[previous.end : episode.start].strip(seps)
+                if between and lone_digit:
+                    to_remove.extend(self._whole_match(matches, episode))
+                else:
+                    previous = episode
+
+        return to_remove
+
+    @staticmethod
+    def _whole_match(matches: Matches, episode: Match) -> list[Match]:
+        """The match and the private ones holding its span, so the freed text becomes a hole again."""
+        return matches.range(
+            episode.start,
+            episode.end,
+            predicate=lambda m: "weak-episode" in m.tags and m.start >= episode.start and m.end <= episode.end,
+        )
 
 
 class RemoveWeakIfSxxExx(Rule):

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -1120,35 +1120,52 @@ class RemoveMisleadingLoneDigitEpisode(Rule):
                 matches.range(filepart.start, filepart.end, predicate=lambda m: m.name == "episode"),
                 key=lambda m: (m.start, m.end),
             )
-            # A lone digit in a parent directory numbers the directory, not the file below it
-            # ("/Volumes/data-1/Series/…"), and one quoted in a bracketed group belongs to that
-            # group's own identifier ("[7.1.7.8.5]", "[t.3.3.d]").
-            is_final_part = index == len(fileparts) - 1
-            for episode in episodes_:
-                if "weak-episode" in episode.tags and len(episode.raw or "") == 1:
-                    quoted = matches.markers.at_match(episode, lambda marker: marker.name == "group", 0)
-                    if not is_final_part or quoted:
-                        to_remove.extend(self._whole_match(matches, episode))
+            in_final_part = index == len(fileparts) - 1
+            misplaced = [
+                episode
+                for episode in episodes_
+                if self._is_lone_digit(episode) and self._numbers_something_else(matches, episode, in_final_part)
+            ]
+            kept = [episode for episode in episodes_ if episode not in misplaced]
+            misplaced.extend(self._detached_from_list(kept))
 
-            anchor = next((match for match in episodes_ if "weak-episode" not in match.tags), None)
-            if anchor is None:
-                continue
-
-            previous = anchor
-            for episode in episodes_:
-                lone_digit = "weak-episode" in episode.tags and len(episode.raw or "") == 1
-                if episode.end <= anchor.start:
-                    if lone_digit:
-                        to_remove.extend(self._whole_match(matches, episode))
-                    continue
-
-                between = (episode.input_string or "")[previous.end : episode.start].strip(seps)
-                if between and lone_digit:
-                    to_remove.extend(self._whole_match(matches, episode))
-                else:
-                    previous = episode
+            for episode in misplaced:
+                to_remove.extend(self._whole_match(matches, episode))
 
         return to_remove
+
+    @staticmethod
+    def _is_lone_digit(episode: Match) -> bool:
+        return "weak-episode" in episode.tags and len(episode.raw or "") == 1
+
+    @staticmethod
+    def _numbers_something_else(matches: Matches, episode: Match, in_final_part: bool) -> bool:
+        """A digit numbering a parent directory ("/Volumes/data-1/…") or a quoted group ("[t.3.3.d]")."""
+        quoted = matches.markers.at_match(episode, lambda marker: marker.name == "group", 0)
+        return not in_final_part or bool(quoted)
+
+    @classmethod
+    def _detached_from_list(cls, episodes_: list[Match]) -> list[Match]:
+        """Lone digits that cannot extend the marked episode list of their filepart."""
+        anchor = next((episode for episode in episodes_ if "weak-episode" not in episode.tags), None)
+        if anchor is None:
+            return []
+
+        detached: list[Match] = []
+        previous = anchor
+        for episode in episodes_:
+            if episode.end <= anchor.start:
+                if cls._is_lone_digit(episode):
+                    detached.append(episode)
+                continue
+
+            between = (episode.input_string or "")[previous.end : episode.start].strip(seps)
+            if between and cls._is_lone_digit(episode):
+                detached.append(episode)
+            else:
+                previous = episode
+
+        return detached
 
     @staticmethod
     def _whole_match(matches: Matches, episode: Match) -> list[Match]:

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -20,19 +20,13 @@ from . import test_yml
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
-# Names whose forced-type result still differs from the inferred one. Each is a lone digit that
-# only the forced-episode patterns pick up — inside a release group, a path segment or a duplicate
-# marker — and pushes out a property. Tracked by #943; entries must be removed as they get fixed.
+# Names whose forced-type result still differs from the inferred one. Both are a number the
+# forced-episode patterns read differently from the inferred ones, with no structural signal
+# left to tell them apart. Tracked by #943; entries must be removed as they get fixed.
 KNOWN_DIVERGENCES = frozenset(
     {
-        "series/Freaks And Geeks/Season 1/Episode 4 - Kim Kelly Is My Friend-eng(1).srt",
-        "/Volumes/data-1/Series/Futurama/Season 3/Futurama_-_S03_DVD_Bonus_-_Deleted_Scenes_Part_3.ogm",
-        "[t.3.3.d]_Mikakunin_de_Shinkoukei_-_12_[720p][5DDC1352].mkv",
-        "[7.1.7.8.5] Foo Bar - 11 (H.264) [5235532D].mkv",
         "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]",
-        "Thumping.Spike.2.E01.DF.WEBRip.720p-DRAMATV.mp4",
         "La Casa di Carta Stagione 2 Episodio 5",
-        "GTTV.E3.All.Access.Live.Day.1.Xbox.Showcase.Preshow.HDTV.x264-SYS",
     }
 )
 
@@ -100,3 +94,33 @@ def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
     result = guessit("Series/Episode/12.Angry.Men.1957.mkv", {"type": "episode"})
     assert result.get("title") == "12 Angry Men"
     assert result.get("year") == 1957
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # A lone digit only the forced-episode patterns see must not evict what owns its span:
+        # the tail of a title, a word of the episode title, a duplicate suffix, a release group,
+        # or a parent directory (#943).
+        ("Thumping.Spike.2.E01.DF.WEBRip.720p-DRAMATV.mp4", {"title": "Thumping Spike 2", "episode": 1}),
+        (
+            "GTTV.E3.All.Access.Live.Day.1.Xbox.Showcase.Preshow.HDTV.x264-SYS",
+            {"episode": 3, "episode_title": "All Access Live Day 1 Xbox Showcase Preshow"},
+        ),
+        ("[t.3.3.d]_Mikakunin_de_Shinkoukei_-_12_[720p][5DDC1352].mkv", {"episode": 12, "release_group": "t.3.3.d"}),
+        ("[7.1.7.8.5] Foo Bar - 11 (H.264) [5235532D].mkv", {"episode": 11, "release_group": "7.8.5"}),
+        (
+            "/Volumes/data-1/Series/Futurama/Season 3/Futurama_-_S03_DVD_Bonus_-_Deleted_Scenes_Part_3.ogm",
+            {"title": "Futurama", "season": 3},
+        ),
+        # A number that does carry the episode numbering stays, marked or not.
+        ("Some Series E01 02 03", {"episode": [1, 2, 3]}),
+        ("Show.Name.Season.4.Episodes.1-12", {"season": 4, "episode": list(range(1, 13))}),
+        ("FooBar.7.PDTV-FlexGet", {"episode": 7}),
+        ("Show Name - 313-315 - s16e03-05", {"absolute_episode": [313, 314, 315], "episode": [3, 4, 5]}),
+    ],
+)
+def test_forced_episode_keeps_a_lone_digit_out_of_other_properties(name: str, expected: dict[str, object]) -> None:
+    result = guessit(name, {"type": "episode"})
+    for prop, value in expected.items():
+        assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -20,9 +20,9 @@ from . import test_yml
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
-# Names whose forced-type result still differs from the inferred one. Both are a number the
-# forced-episode patterns read differently from the inferred ones, with no structural signal
-# left to tell them apart. Tracked by #943; entries must be removed as they get fixed.
+# Names whose forced-type result still differs from the inferred one: a half-episode number
+# (02.5) and an episode word the numeral pattern leaves dangling. Tracked by #948; entries
+# must be removed as they get fixed.
 KNOWN_DIVERGENCES = frozenset(
     {
         "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]",


### PR DESCRIPTION
Fixes 6 of the 8 divergences listed in #943. The two that remain are a different shape and are now tracked by #948, so this closes the lone-digit issue.

## Problem

Only a forced `type=episode` reads a **single digit** as an episode (the `(?P<episode>\d)` chain is
disabled otherwise). That pattern fires wherever a digit sits, and then evicts whatever owned the
span — so forcing the type guessit already inferred changed the result on 8 corpus names.

## Fix

A new rule discards such a digit when it cannot belong to the episode numbering:

- **quoted in a bracketed group** — `[7.1.7.8.5]`, `[t.3.3.d]` are release-group identifiers;
- **in a non-final path part** — `/Volumes/data-1/…` numbers a directory, not the file;
- **unable to extend a marked episode list** — a list grows rightwards from its marker and stays
  glued to it (`E01 02 03`), so a digit sitting *before* the first marked episode, or cut off from
  the last one by actual content, is numbering something else.

Two details that made the difference:

- it runs **before anything is carved out** of the name (rebulk executes rules by *decreasing*
  priority), and removes the **private parent** matches holding the span — otherwise the digit
  disappeared from the output but the title stayed truncated around the hole it left;
- it is limited to numbers whose raw text is **one digit**, which is what keeps absolute episodes
  like `Show Name - 313-315 - s16e03-05` and `Seitokai Yakuindomo - 14 …` untouched.

The rule only applies when the type is forced to episode — the sole mode that reads a lone digit
that way.

## Result

| Name (forced `type=episode`) | Before | After |
| --- | --- | --- |
| `Thumping.Spike.2.E01…` | `title: "Thumping Spike"`, `episode: [2, 1]` | `title: "Thumping Spike 2"`, `episode: 1` |
| `GTTV.E3.All.Access.Live.Day.1…` | `episode: [3, 1]`, truncated `episode_title` | `episode: 3`, full `episode_title` |
| `[t.3.3.d]_Mikakunin…` | `release_group` lost | `release_group: "t.3.3.d"` |
| `[7.1.7.8.5] Foo Bar - 11…` | `release_group` lost | `release_group: "7.8.5"` |
| `/Volumes/data-1/…/Futurama…` | `title: "data-1"`, `episode: 1` | `title: "Futurama"` |
| `…Episode 4 - …-eng(1).srt` | `episode: [4, 1]`, `language` | `episode: 4`, `subtitle_language` |

`KNOWN_DIVERGENCES` drops from 8 names to 2. The remaining two are a different shape — a number the
forced patterns read differently, with no structural signal left to tell them apart — and moved to
**#948**:

```text
[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]   episode 2 + episode_title "5"  vs  episode [2, 5]
La Casa di Carta Stagione 2 Episodio 5              episode_title "Episodio" appears
```

## Verification

- Over the whole corpus (996 names × 3 modes) versus v4.2.1: **6 names change, all in the forced
  episode mode**. The inferred and `type=movie` modes are **byte-identical**.
- Full suite green: **2376 passed**, 4 skipped — also under the `regex` module.
- Cross-parser green: **5 passed**.
- 9 new parametrized cases pin both the fixed names and the ones that must keep their numbering
  (`E01 02 03`, `Episodes.1-12`, `FooBar.7`, `313-315 s16e03-05`).

closes #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)
