### PR TITLE
fix: keep the properties unrelated to episodes under a forced type=movie

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -588,7 +588,7 @@
         "Proof": {"string": "Proof", "tags": ["at-end", "not-a-release-group"]},
         "Obfuscated": {"string": ["Obfuscated", "Scrambled"], "tags": ["at-end", "not-a-release-group"]},
         "Repost": {"string": ["xpost", "postbot", "asrequested"], "tags": "not-a-release-group"},
-        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "season_words": ["seasons?", "series?"], "complete_article_words": ["The"]}
+        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "season_words": ["seasons?", "series?"], "complete_article_words": ["The"], "season_number_separators": ["&", "and"]}
       },
       "art": {
         "poster": "Poster",

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -150,6 +150,9 @@ def complete_words(
 ) -> None:
     """
     Custom pattern to find complete seasons from words.
+
+    ``season_number_separators`` are the tokens that may join the season numbers a marker spans,
+    e.g. the ``&`` of "Seasons 1 & 2 - Complete"; plain separators are always allowed.
     """
     season_words_pattern = build_or_pattern(season_words)
     complete_article_words_pattern = build_or_pattern(complete_article_words)

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -142,12 +142,19 @@ def opening_ending_credits(rebulk: Rebulk) -> None:
     add(r"ED", "Ending Credits", ignore_case=False)
 
 
-def complete_words(rebulk: Rebulk, season_words: Iterable[str], complete_article_words: Iterable[str]) -> None:
+def complete_words(
+    rebulk: Rebulk,
+    season_words: Iterable[str],
+    complete_article_words: Iterable[str],
+    season_number_separators: Iterable[str],
+) -> None:
     """
     Custom pattern to find complete seasons from words.
     """
     season_words_pattern = build_or_pattern(season_words)
     complete_article_words_pattern = build_or_pattern(complete_article_words)
+    # The season numbers listed between the season word and the marker: "1", "1 & 2", "1 and 2".
+    season_numbers_pattern = r"(?:-+(?:\d+|" + build_or_pattern(season_number_separators, escape=True) + r"))+-+"
 
     def validate_complete(match: Match) -> bool:
         """
@@ -175,6 +182,20 @@ def complete_words(rebulk: Rebulk, season_words: Iterable[str], complete_article
         value={"other": "Complete"},
         tags=["release-group-prefix"],
         validator={"__parent__": and_(seps_surround, validate_complete)},
+    )
+
+    # "Season 1 Complete", "Seasons 1 & 2 - Complete": the season numbers sit between the season
+    # word and the marker, so the adjacency pattern above cannot see the word. Anchoring on the
+    # numbered season word keeps the marker alive even when nothing matched the numbers — the
+    # season chain is off under a forced ``type=movie`` (#944).
+    rebulk.regex(
+        season_words_pattern + season_numbers_pattern + "(?P<other>Complete)",
+        children=True,
+        private_parent=True,
+        validate_all=True,
+        value={"other": "Complete"},
+        tags=["release-group-prefix"],
+        validator={"__parent__": seps_surround},
     )
 
 

--- a/guessit/rules/properties/release_group.py
+++ b/guessit/rules/properties/release_group.py
@@ -140,13 +140,13 @@ def leading_anime_group(matches: Matches, filepart: Match) -> Match | None:
     return None
 
 
-_seps_class = "[" + re.escape(seps) + "]"
+_SEPS_CHARS = re.escape(seps)
 
 #: A trailing hole made of a numeric run and a final dash-separated word, e.g. ``.313-314-GROUP``.
 #: Digits and separators alone cannot be a title, so the last word stays a release group even when
 #: nothing claimed the numbers.
 _NUMERIC_RUN_THEN_GROUP = re.compile(
-    rf"^{_seps_class}?\d+(?:{_seps_class}+\d+)*-(?P<group>[^{re.escape(seps)}]{{2,}})$"
+    rf"^[{_SEPS_CHARS}]?\d+(?:[{_SEPS_CHARS}]+\d+)*-(?P<group>[^{_SEPS_CHARS}]{{2,}})$"
 )
 
 

--- a/guessit/rules/properties/release_group.py
+++ b/guessit/rules/properties/release_group.py
@@ -140,6 +140,16 @@ def leading_anime_group(matches: Matches, filepart: Match) -> Match | None:
     return None
 
 
+_seps_class = "[" + re.escape(seps) + "]"
+
+#: A trailing hole made of a numeric run and a final dash-separated word, e.g. ``.313-314-GROUP``.
+#: Digits and separators alone cannot be a title, so the last word stays a release group even when
+#: nothing claimed the numbers.
+_NUMERIC_RUN_THEN_GROUP = re.compile(
+    rf"^{_seps_class}?\d+(?:{_seps_class}+\d+)*-(?P<group>[^{re.escape(seps)}]{{2,}})$"
+)
+
+
 class DashSeparatedReleaseGroup(Rule):
     """
     Detect dash separated release groups that might appear at the end or at the beginning of a release name.
@@ -288,7 +298,34 @@ class DashSeparatedReleaseGroup(Rule):
 
         if candidate and self.is_valid(matches, candidate, start, end, at_end):
             return candidate
+        if at_end:
+            return self.detect_after_numeric_run(matches, start, end)
         return None
+
+    @classmethod
+    def detect_after_numeric_run(cls, matches: Matches, start: int, end: int) -> Match | None:
+        """
+        Detach a trailing dash separated group from an unclaimed numeric run.
+
+        ``Bleach.s16e03-04.313-314-GROUP`` leaves ``.313-314-GROUP`` as a single hole whenever no
+        rule claims the absolute episode run — the weak episode chains are off under a forced
+        ``type=movie`` (#944). The run is anchored on the season/episode markers it follows, so the
+        trailing word behind it is a release group rather than the tail of a title.
+        """
+        hole = matches.holes(start, end, index=-1, predicate=lambda m: m.end == end and m.raw)
+        if not hole or hole.raw is None:
+            return None
+
+        numeric_run = _NUMERIC_RUN_THEN_GROUP.match(hole.raw)
+        if not numeric_run or int_coercable(numeric_run.group("group")):
+            return None
+
+        previous = matches.range(start, hole.start, index=-1, predicate=lambda m: not m.private)
+        if not previous or previous.name not in ("season", "episode"):
+            return None
+
+        # The candidate keeps its leading dash, as the ones the branches above return do.
+        return Match(hole.start + numeric_run.start("group") - 1, hole.end, input_string=hole.input_string)
 
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         if matches.named("release_group"):

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -103,6 +103,9 @@ def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict
         ("Series/Mad Men Season 1 Complete/Mad.Men.S01E01.avi", {"title": "Mad Men", "other": "Complete"}),
         ("Something Seasons 1 & 2 - Complete", {"title": "Something", "other": "Complete"}),
         ("Something Seasons 4 Complete", {"title": "Something", "other": "Complete"}),
+        # An absolute episode run nothing claims must not swallow the trailing release group.
+        ("Bleach.s16e03-04.313-314-GROUP", {"title": "Bleach", "release_group": "GROUP"}),
+        ("Show.Name.16x03-05.313-315-GROUP", {"title": "Show Name", "release_group": "GROUP"}),
     ],
 )
 def test_forced_movie_keeps_properties_unrelated_to_episodes(name: str, expected: dict[str, object]) -> None:

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -114,6 +114,19 @@ def test_forced_movie_keeps_properties_unrelated_to_episodes(name: str, expected
         assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Show.Name.2019.313-314-GROUP",
+        "Show Name 313-314-GROUP",
+        "12-Monkeys",
+    ],
+)
+def test_a_numeric_run_alone_does_not_yield_a_release_group(name: str) -> None:
+    """Only a run anchored on a season/episode marker vouches for the word behind it (#944)."""
+    assert "release_group" not in guessit(name, {"type": "movie"})
+
+
 def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
     """A parent directory named "Episode" must not vouch for a number in the file below it."""
     result = guessit("Series/Episode/12.Angry.Men.1957.mkv", {"type": "episode"})

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -95,6 +95,22 @@ def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict
         assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
 
 
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # The "Complete" marker is anchored on the numbered season word, so it survives the season
+        # chain being off (#944).
+        ("Series/Mad Men Season 1 Complete/Mad.Men.S01E01.avi", {"title": "Mad Men", "other": "Complete"}),
+        ("Something Seasons 1 & 2 - Complete", {"title": "Something", "other": "Complete"}),
+        ("Something Seasons 4 Complete", {"title": "Something", "other": "Complete"}),
+    ],
+)
+def test_forced_movie_keeps_properties_unrelated_to_episodes(name: str, expected: dict[str, object]) -> None:
+    result = guessit(name, {"type": "movie"})
+    for prop, value in expected.items():
+        assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
+
+
 def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
     """A parent directory named "Episode" must not vouch for a number in the file below it."""
     result = guessit("Series/Episode/12.Angry.Men.1957.mkv", {"type": "episode"})


### PR DESCRIPTION
Forcing `type=movie` disables the weak-episode chains — that is what makes the mode useful — but two unrelated properties were collateral damage on 5 corpus names: `other: Complete` and `release_group`.

closes #944

## `other: Complete` (3 names)

The marker is tagged `has-neighbor`, so it only survives next to another match. In `Season 1 Complete` that neighbour is the season itself, which a forced `type=movie` leaves unmatched (the season-word chain is off there), and the marker went with it.

A pattern spanning the numbered season word up to the token now anchors it on its own evidence, whatever claims the numbers:

```
Series/Mad Men Season 1 Complete/Mad.Men.S01E01.avi
Something Seasons 1 & 2 - Complete
Something Seasons 4 Complete
```

The list separators between the numbers (`&`, `and`) live in `advanced_config.other._complete_words.season_number_separators`.

## `release_group` (2 names)

`Bleach.s16e03-04.313-314-GROUP` leaves `.313-314-GROUP` as a single hole when nothing reads the absolute-episode run, and `-GROUP` was swallowed by the resulting `alternative_title`. Digits and separators cannot be a title, so `DashSeparatedReleaseGroup` now detaches the trailing word behind a numeric run that follows a season/episode marker.

## Side effects

Measured by diffing auto vs `--type movie` vs `--type episode` over the whole yaml corpus (996 names), 9 names change, all of them **in `--type movie` only** — the 5 above plus 4 that get cleaner:

| Name | before | after |
| --- | --- | --- |
| `Adam-12 1968 Season 1 Complete x264 [i_c]/Adam-12 S01E02 …` | `title: ['Adam-12', 'Season 1']` | `title: Adam-12` |
| `series/Psych/Psych S02 Season 2 Complete …` (2 names) | `title: ['Psych', 'Season 2']` | `title: Psych` |
| `The Simpsons - Season 2 Complete [DVDRIP VP7 KEGGERMAN` | `alternative_title: Season 2` | dropped |

No inferred (auto) result changes anywhere in the corpus.

## Tests

- `test_forced_type.py`: 5 parametrized cases pinning the properties above under `--type movie`.
- Full suite `2381 passed`, `pytest -m cross_parser` green (no new divergence), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FciPHULDaS2HBNqYXcfMC3