### PR TITLE
fix(episodes): settle the two forced-type divergences left

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -77,6 +77,19 @@ The `SxxExx` chain extends across a weak `.` separator to the **consecutive** nu
 `S01E02.5.Kings` → episode `2`, episode_title `5 Kings`. Telling `S01E02.3.Kings` (title) apart from
 `S01E02.03` (range) needs to know `Kings` is a title, which is the same ambiguity as #743/#746.
 
+### #948 — a half-episode number
+
+```text
+[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]
+  episode: 2   episode_title: "5"   episode_details: Special
+  wanted -> a single "episode 2.5" notion
+```
+
+`02.5` numbers a special sitting between episodes 2 and 3. Episode numbers are integers, so the
+fractional part has nowhere to go: guessit keeps it out of the numbering — it is neither a second
+episode nor a range — and it falls back to the episode title. Carrying it would need a new property,
+or a non-integer `episode` every consumer of the schema would have to follow.
+
 ### #744 — episode title made of numbers and hyphens
 
 ```text

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -416,8 +416,12 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         disabled=lambda context: context.get("type") == "episode" or is_disabled(context, "episode"),
     )
 
+    # A roman numeral can be read out of the letters a longer marker continues with ("Ep" then
+    # "i" of "Episodio"), so the marker only counts when it ends on a word boundary. The digit
+    # variant above needs no such guard: a letter can never start its number.
     rebulk.regex(
         build_or_pattern(episode_words, name="episodeMarker")
+        + r"(?![^\W\d_])"
         + r"-?-?(?:(?:№|#)-?)?(?P<episode>"
         + numeral
         + ")"

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -1103,8 +1103,9 @@ class RemoveMisleadingLoneDigitEpisode(Rule):
     wherever a digit sits — including inside a release group, in a parent directory, or in the
     tail of a title — where it then evicts whatever owned that span. Such a digit is discarded
     when it cannot be part of the episode numbering: quoted in a bracketed group, sitting in a
-    non-final path part, or unable to extend a marked episode list (a list grows rightwards from
-    its marker and stays glued to it, as in "E01 02 03") (#943).
+    non-final path part, behind the dot of a decimal number, or unable to extend a marked episode
+    list (a list grows rightwards from its marker and stays glued to it, as in "E01 02 03")
+    (#943, #948).
 
     Runs before anything is carved out of the name (rebulk executes rules by decreasing priority),
     so the freed span goes back to the title instead of leaving a hole behind.
@@ -1128,7 +1129,10 @@ class RemoveMisleadingLoneDigitEpisode(Rule):
             misplaced = [
                 episode
                 for episode in episodes_
-                if self._is_lone_digit(episode) and self._numbers_something_else(matches, episode, in_final_part)
+                if self._is_lone_digit(episode)
+                and (
+                    self._numbers_something_else(matches, episode, in_final_part) or self._fraction_of_a_number(episode)
+                )
             ]
             kept = [episode for episode in episodes_ if episode not in misplaced]
             misplaced.extend(self._detached_from_list(kept))
@@ -1147,6 +1151,12 @@ class RemoveMisleadingLoneDigitEpisode(Rule):
         """A digit numbering a parent directory ("/Volumes/data-1/…") or a quoted group ("[t.3.3.d]")."""
         quoted = matches.markers.at_match(episode, lambda marker: marker.name == "group", 0)
         return not in_final_part or bool(quoted)
+
+    @staticmethod
+    def _fraction_of_a_number(episode: Match) -> bool:
+        """A digit behind the dot of a decimal number ("02.5"): a half episode, not a second one."""
+        before = (episode.input_string or "")[: episode.start]
+        return len(before) > 1 and before[-1] == "." and before[-2].isdigit()
 
     @classmethod
     def _detached_from_list(cls, episodes_: list[Match]) -> list[Match]:

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -21,12 +21,11 @@ from . import test_yml
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 # Names whose forced-type result still differs from the inferred one: a half-episode number
-# (02.5) and an episode word the numeral pattern leaves dangling. Tracked by #948; entries
-# must be removed as they get fixed.
+# (02.5) whose fractional digit the forced patterns read as a second episode. Tracked by #948;
+# entries must be removed as they get fixed.
 KNOWN_DIVERGENCES = frozenset(
     {
         "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]",
-        "La Casa di Carta Stagione 2 Episodio 5",
     }
 )
 
@@ -87,6 +86,23 @@ def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict
     result = guessit(name, {"type": "episode"})
     for prop, value in expected.items():
         assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "La Casa di Carta Stagione 2 Episodio 5",
+        "Show Name Episodio 5",
+        "Show Name Episodios 5",
+        "Show Name Capitulos 5",
+        "Show Name Episodul 5",
+    ],
+)
+def test_forced_episode_consumes_the_whole_episode_word(name: str) -> None:
+    """The numeral variant claims its marker instead of a shorter one a roman numeral extends (#948)."""
+    result = guessit(name, {"type": "episode"})
+    assert result.get("episode") == 5
+    assert "episode_title" not in result
 
 
 @pytest.mark.parametrize(

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -15,6 +15,8 @@ import pytest
 import yaml
 
 from .. import guessit
+from ..options import load_config
+from ..rules.properties.episodes import _split_words
 from ..yamlutils import OrderedDictYAMLLoader
 from . import test_yml
 
@@ -73,21 +75,29 @@ def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict
         assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
 
 
-@pytest.mark.parametrize(
-    "name",
-    [
-        "La Casa di Carta Stagione 2 Episodio 5",
-        "Show Name Episodio 5",
-        "Show Name Episodios 5",
-        "Show Name Capitulos 5",
-        "Show Name Episodul 5",
-    ],
-)
-def test_forced_episode_consumes_the_whole_episode_word(name: str) -> None:
-    """The numeral variant claims its marker instead of a shorter one a roman numeral extends (#948)."""
-    result = guessit(name, {"type": "episode"})
-    assert result.get("episode") == 5
-    assert "episode_title" not in result
+def marker_names(word_key: str) -> list[str]:
+    """One "Show Name <marker> 5" per configured season/episode word, reversed for number-first ones."""
+    config = load_config({"no_user_config": True})["advanced_config"]["episodes"]
+    words, numfirst = _split_words(config[word_key])
+    return [f"Show Name 5 {word}" if word in set(numfirst) else f"Show Name {word} 5" for word in words]
+
+
+@pytest.mark.parametrize("options", [{}, {"type": "episode"}], ids=["inferred", "forced"])
+@pytest.mark.parametrize("name", marker_names("episode_words"))
+def test_every_episode_word_is_claimed_by_its_number(name: str, options: dict[str, str]) -> None:
+    """A marker is claimed whole: a shorter one leaving its tail in the title is the #948 bug."""
+    result = guessit(name, options)
+    assert result.get("episode") == 5, f"episode: {dict(result)}"
+    assert result.get("title") == "Show Name", f"title: {dict(result)}"
+
+
+@pytest.mark.parametrize("options", [{}, {"type": "episode"}], ids=["inferred", "forced"])
+@pytest.mark.parametrize("name", marker_names("season_words"))
+def test_every_season_word_is_claimed_by_its_number(name: str, options: dict[str, str]) -> None:
+    """Same guard on the season side, where the numeral pattern is shared by both modes."""
+    result = guessit(name, options)
+    assert result.get("season") == 5, f"season: {dict(result)}"
+    assert result.get("title") == "Show Name", f"title: {dict(result)}"
 
 
 @pytest.mark.parametrize(

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -20,15 +20,6 @@ from . import test_yml
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
-# Names whose forced-type result still differs from the inferred one: a half-episode number
-# (02.5) whose fractional digit the forced patterns read as a second episode. Tracked by #948;
-# entries must be removed as they get fixed.
-KNOWN_DIVERGENCES = frozenset(
-    {
-        "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]",
-    }
-)
-
 
 def corpus_names() -> list[str]:
     """Every input string of the yaml corpus, minus the entries pinned to their own options."""
@@ -47,9 +38,8 @@ def corpus_names() -> list[str]:
 
 
 def test_forcing_the_inferred_type_is_a_no_op() -> None:
-    names = corpus_names()
     divergences = {}
-    for name in names:
+    for name in corpus_names():
         inferred = guessit(name)
         guessed_type = inferred.get("type")
         if guessed_type not in ("movie", "episode"):
@@ -58,14 +48,9 @@ def test_forcing_the_inferred_type_is_a_no_op() -> None:
         if dict(forced) != dict(inferred):
             divergences[name] = (dict(inferred), dict(forced))
 
-    unexpected = {name: diff for name, diff in divergences.items() if name not in KNOWN_DIVERGENCES}
-    assert not unexpected, "forcing the inferred type changed the result:\n" + "\n".join(
-        f"  {name}\n    inferred={inferred}\n    forced  ={forced}" for name, (inferred, forced) in unexpected.items()
+    assert not divergences, "forcing the inferred type changed the result:\n" + "\n".join(
+        f"  {name}\n    inferred={inferred}\n    forced  ={forced}" for name, (inferred, forced) in divergences.items()
     )
-
-    scanned = set(names)
-    stale = {name for name in KNOWN_DIVERGENCES if name in scanned and name not in divergences}
-    assert not stale, f"these names no longer diverge, drop them from KNOWN_DIVERGENCES: {sorted(stale)}"
 
 
 @pytest.mark.parametrize(
@@ -166,6 +151,9 @@ def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
         ("Show.Name.Season.4.Episodes.1-12", {"season": 4, "episode": list(range(1, 13))}),
         ("FooBar.7.PDTV-FlexGet", {"episode": 7}),
         ("Show Name - 313-315 - s16e03-05", {"absolute_episode": [313, 314, 315], "episode": [3, 4, 5]}),
+        # The fractional digit of a half episode is not a second episode (#948).
+        ("[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]", {"episode": 2, "episode_title": "5"}),
+        ("Show.Name.-.12.5.(Special)", {"episode": 12, "episode_title": "5"}),
     ],
 )
 def test_forced_episode_keeps_a_lone_digit_out_of_other_properties(name: str, expected: dict[str, object]) -> None:


### PR DESCRIPTION
The two names of #948 parsed differently depending on whether the type was inferred or forced. Both
are now settled, and the whole yaml corpus parses identically in either mode — the
`KNOWN_DIVERGENCES` list of `test_forced_type.py` is gone.

## A dangling episode word

```text
La Casa di Carta Stagione 2 Episodio 5
  before, forced -> season: 2, episode: 5, episode_title: "Episodio"
```

The numeral variant of the episode-word pattern — the one a forced `type=episode` swaps in — could
settle on a shorter marker and read the letters the real one continues with as a roman numeral:
`Episodio` gave the marker `Ep` and the episode `i`. That match then failed validation, and the
marker was left dangling in the name, where it became the episode title. The marker is now anchored
on a word boundary, so only a whole word counts; the digit variant needs no such guard, since a
letter can never start its number.

## A half-episode number split into a list

```text
[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]
  before, forced -> episode: [2, 5]
```

Only a forced `type=episode` reads a lone digit as an episode, and it did so behind the dot of a
decimal number. Such a digit is the fractional part of the number in front of it, never an episode
of its own, so `RemoveMisleadingLoneDigitEpisode` now discards it — leaving the inferred reading
(`episode: 2`, the `5` falling back to the episode title, which is what the corpus and
`docs/known-limitations.md` already pin for `S01E02.5.Kings`).

Numbering a half episode *as such* is a separate, schema-level question (a new property, or a
non-integer `episode`); it is recorded in `docs/known-limitations.md` rather than decided here.

## Validation

- full suite + cross-parser tests green, ruff and mypy clean
- the whole corpus (2062 names) parsed in the inferred, forced-episode and forced-movie modes before
  and after: exactly the two intended outputs change, nothing else

closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxY6td16TcG8HYCQAnBezP