### PR TITLE
fix(episodes): know the "of" word of the languages the markers cover

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -362,7 +362,12 @@
       "ordinal_suffix": "(?:ª|º|°|a|o|-?(?:й|я|е|го|ая|ый|ое))?",
       "of_words": [
         "of",
-        "sur"
+        "sur",
+        "de",
+        "di",
+        "von",
+        "van",
+        "din"
       ],
       "all_words": [
         "All"

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -367,7 +367,8 @@
         "di",
         "von",
         "van",
-        "din"
+        "din",
+        "из"
       ],
       "all_words": [
         "All"

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -771,17 +771,29 @@ class CountValidator(Rule):
         season_count: list[Match] = []
 
         for count in matches.named("count"):
-            previous = matches.previous(count, lambda match: match.name in ["episode", "season"], 0)
-            if previous:
-                if previous.name == "episode":
-                    episode_count.append(count)
-                elif previous.name == "season":
-                    season_count.append(count)
-            else:
+            numbered = self._numbered_by(matches, count)
+            if numbered is None:
                 to_remove.append(count)
+            elif numbered.name == "episode":
+                episode_count.append(count)
+            else:
+                season_count.append(count)
         if to_remove or episode_count or season_count:
             return to_remove, episode_count, season_count
         return False
+
+    @staticmethod
+    def _numbered_by(matches: Matches, count: Match) -> Match | None:
+        """The episode or season the count belongs to: the last one its own match holds.
+
+        Scoped to the count's match rather than to the nearest neighbour, because another property
+        can sit on the linking word itself — "de" is the German language code as much as it is the
+        Spanish "of" — and would then hide the number the count completes.
+        """
+        numbers = matches.range(
+            count.initiator.start, count.start, predicate=lambda match: match.name in ("episode", "season")
+        )
+        return numbers[-1] if numbers else None
 
 
 class SeePatternRange(Rule):

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -382,13 +382,16 @@ def episodes(config: dict[str, Any]) -> Rebulk:
 
     # Non-English convention where the number precedes the keyword:
     #   "1ª Temporada", "3 сезон", "5-й сезон", "2.Sezon" (season); "24 серия", "7.Bölüm" (episode).
-    # An optional ordinal suffix (ª/º/°, Portuguese a/o, Russian -й/-я/…) may sit between the two.
+    # An optional ordinal suffix (ª/º/°, Portuguese a/o, Russian -й/-я/…) may sit between the two,
+    # and the total may follow the keyword ("5 серия из 12"), as it does in the word-first patterns.
+    of_count = r"(?:@?" + build_or_pattern(of_words) + r"@?(?P<count>\d+))?"
     rebulk.regex(
         r"(?P<season>\d{1,2})"
         + ordinal_suffix
         + r"@?@?"
         + build_or_pattern(season_words_numfirst, name="seasonMarker")
-        + r"(?![^\W\d_])",
+        + r"(?![^\W\d_])"
+        + of_count,
         tags=["SxxExx", "numfirst"],
         formatter={"season": parse_numeral},
         disabled=is_season_episode_disabled,
@@ -398,7 +401,8 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         + ordinal_suffix
         + r"@?@?"
         + build_or_pattern(episode_words_numfirst, name="episodeMarker")
-        + r"(?![^\W\d_])",
+        + r"(?![^\W\d_])"
+        + of_count,
         tags=["SxxExx", "numfirst"],
         formatter={"episode": parse_numeral},
         disabled=lambda context: is_disabled(context, "episode"),

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -1038,6 +1038,62 @@
   video_codec: H.264
   year: 2013
 
+# The word linking a number to its total, in the languages the markers already cover.
+? Show.Name.Capitulo.5.de.12.HDTV.x264-GRUPO
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  source: HDTV
+  video_codec: H.264
+  release_group: GRUPO
+
+? Serie.Temporada.1.de.5.1080p.WEB-DL
+: title: Serie
+  season: 1
+  season_count: 5
+  screen_size: 1080p
+  source: Web
+
+? Show.Name.Episodio.5.di.12.ITA.1080p.BluRay
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  language: it
+  screen_size: 1080p
+  source: Blu-ray
+
+? Show.Name.Stagione.1.di.5.720p
+: title: Show Name
+  season: 1
+  season_count: 5
+  screen_size: 720p
+
+? Show.Name.Folge.5.von.12.German.HDTV
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  language: de
+  source: HDTV
+
+? Show.Name.Aflevering.5.van.12.1080p
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  screen_size: 1080p
+
+? Show.Name.Episodul.5.din.12.HDTV
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  source: HDTV
+
+# "av" is left out of the of-words: it would read the AV1 codec as a total (#950).
+? Show.Name.Season.2.AV1.1080p
+: title: Show Name
+  season: 2
+  screen_size: 1080p
+  -season_count: 1
+
 ? Something.S04E05E09
 : episode: # 1.x guessit this as a range from 5 to 9. But not sure if it should ...
   - 5

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -1087,6 +1087,14 @@
   episode_count: 12
   source: HDTV
 
+# Russian numbers its episode before the marker, and its total after it.
+? Show.Name.5.серия.из.12.WEB-DL.1080p
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  source: Web
+  screen_size: 1080p
+
 # "av" is left out of the of-words: it would read the AV1 codec as a total (#950).
 ? Show.Name.Season.2.AV1.1080p
 : title: Show Name


### PR DESCRIPTION
`of_words` held only `of` and `sur`, while `episode_words` and `season_words` each cover a dozen
languages. A release numbering its episode in one of those languages and its total with that
language's "of" was therefore only half understood — and on the season side the number was not
claimed at all.

```text
Show.Name.Capitulo.5.de.12    before -> episode: [5, 12]   episode_title: "de"
                              after  -> episode: 5   episode_count: 12
Show.Name.Stagione.1.di.5     before -> season: 1   episode_title: "di 5"
                              after  -> season: 1   season_count: 5
Show.Name.5.серия.из.12       before -> episode: 5   episode_title: "из 12"
                              after  -> episode: 5   episode_count: 12
```

## What is in

- **`de` (es/pt), `di` (it), `von` (de), `van` (nl), `din` (ro), `из` (ru)** added to `of_words` —
  the "of" of every language whose marker guessit already knows.
- **Counting across the linking word.** `CountValidator` only looked at the count's immediate
  neighbour, and `de` is the German language code as much as it is the Spanish "of": that language
  match, landing on the linking word, hid the very number the count completes. The count is now
  matched against the last episode or season inside its own match, which is where it always
  belongs. (Reverting just that part makes the two Spanish fixtures fail, and only those.)
- **A total after a number-first marker.** Languages that number before the keyword ("5 серия",
  "7. Bölüm") had no "of" branch at all, so the total could never attach. They now take the same
  optional branch as the word-first patterns.

## What is deliberately left out

- **Swedish/Norwegian `av`** — it would read the AV1 codec of `Show.Name.Season.2.AV1.1080p` as a
  total (`season_count: 1`). A fixture pins that name so a later addition cannot slip it back in.
- **Polish `z`** — a single letter between two numbers is too weak a signal to be worth it.
- Turkish and Hungarian attach their total with a suffix on the number itself, a different shape
  from the `<number> <word> <total>` these patterns describe.

## Validation

- 8 new corpus fixtures, one per language plus the AV1 guard; full suite + cross-parser green,
  ruff and mypy clean
- the whole corpus (2062 names) parsed in the inferred, forced-episode and forced-movie modes
  before and after: **no output changes at all** — the new words only fire on shapes nothing
  claimed before
- checked against plausible false positives, all left untouched: `Los.7.de.Chicago.2020`,
  `Jean.Claude.Van.Damme.2008`, `La.Casa.di.Carta.S01E05`, `Duck.Dynasty.S09E09.Van.He-llsing`
  (the linking word only counts between two numbers)

Two unrelated gaps surfaced while testing, left alone here: `S01E05.of.12` does not attach its
total (the `SxxExx` pattern has no "of" branch — same before this PR), and `Parte` is not a known
`part` word, so `El.Padrino.Parte.2.de.3` reads as an episode exactly like the English
`Part.2.of.3` already does.

closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxY6td16TcG8HYCQAnBezP