### PR TITLE
release: v4.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,12 @@ jobs:
           git config --global user.name "github-actions"
 
       - name: Bump version
+        # A pull_request checkout is a detached merge commit, which python-semantic-release
+        # refuses to version ("Detached HEAD state cannot match any release groups") with a
+        # non-zero exit — unlike a branch outside the release groups, which it just skips.
+        # Artifacts built from a pull request are never published, so they keep the version
+        # already in pyproject.toml.
+        if: github.event_name != 'pull_request'
         run: uvx --from python-semantic-release semantic-release version --no-commit --no-tag --no-push
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -217,6 +223,8 @@ jobs:
           git config --global user.name "github-actions"
 
       - name: Bump version
+        # Skipped on a pull request: detached merge commit, see the build job.
+        if: github.event_name != 'pull_request'
         run: uvx --from python-semantic-release semantic-release version --no-commit --no-tag --no-push
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -259,6 +267,8 @@ jobs:
           git config --global user.name "github-actions"
 
       - name: Bump version
+        # Skipped on a pull request: detached merge commit, see the build job.
+        if: github.event_name != 'pull_request'
         run: uvx --from python-semantic-release semantic-release version --no-commit --no-tag --no-push
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -301,6 +311,8 @@ jobs:
           git config --global user.name "github-actions"
 
       - name: Bump version
+        # Skipped on a pull request: detached merge commit, see the build job.
+        if: github.event_name != 'pull_request'
         run: uvx --from python-semantic-release semantic-release version --no-commit --no-tag --no-push
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -77,6 +77,19 @@ The `SxxExx` chain extends across a weak `.` separator to the **consecutive** nu
 `S01E02.5.Kings` → episode `2`, episode_title `5 Kings`. Telling `S01E02.3.Kings` (title) apart from
 `S01E02.03` (range) needs to know `Kings` is a title, which is the same ambiguity as #743/#746.
 
+### #948 — a half-episode number
+
+```text
+[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]
+  episode: 2   episode_title: "5"   episode_details: Special
+  wanted -> a single "episode 2.5" notion
+```
+
+`02.5` numbers a special sitting between episodes 2 and 3. Episode numbers are integers, so the
+fractional part has nowhere to go: guessit keeps it out of the numbering — it is neither a second
+episode nor a range — and it falls back to the episode title. Carrying it would need a new property,
+or a non-integer `episode` every consumer of the schema would have to follow.
+
 ### #744 — episode title made of numbers and hyphens
 
 ```text

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -362,7 +362,12 @@
       "ordinal_suffix": "(?:ª|º|°|a|o|-?(?:й|я|е|го|ая|ый|ое))?",
       "of_words": [
         "of",
-        "sur"
+        "sur",
+        "de",
+        "di",
+        "von",
+        "van",
+        "din"
       ],
       "all_words": [
         "All"

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -588,7 +588,7 @@
         "Proof": {"string": "Proof", "tags": ["at-end", "not-a-release-group"]},
         "Obfuscated": {"string": ["Obfuscated", "Scrambled"], "tags": ["at-end", "not-a-release-group"]},
         "Repost": {"string": ["xpost", "postbot", "asrequested"], "tags": "not-a-release-group"},
-        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "season_words": ["seasons?", "series?"], "complete_article_words": ["The"]}
+        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "season_words": ["seasons?", "series?"], "complete_article_words": ["The"], "season_number_separators": ["&", "and"]}
       },
       "art": {
         "poster": "Poster",

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -367,7 +367,8 @@
         "di",
         "von",
         "van",
-        "din"
+        "din",
+        "из"
       ],
       "all_words": [
         "All"

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -546,6 +546,7 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         EpisodeNumberSeparatorRange(range_separators),
         SeasonSeparatorRange(range_separators),
         RemoveWeakIfMovie(episode_words),
+        RemoveMisleadingLoneDigitEpisode,
         RemoveWeakIfSxxExx,
         RemoveWeakDuplicate,
         EpisodeDetailValidator,
@@ -1088,6 +1089,92 @@ class RemoveWeak(Rule):
         if to_remove or to_append:
             return to_remove, to_append
         return False
+
+
+class RemoveMisleadingLoneDigitEpisode(Rule):
+    """
+    Remove a lone digit read as an episode while it plainly numbers something else.
+
+    Only a forced `type=episode` reads a single digit as an episode, and that pattern fires
+    wherever a digit sits — including inside a release group, in a parent directory, or in the
+    tail of a title — where it then evicts whatever owned that span. Such a digit is discarded
+    when it cannot be part of the episode numbering: quoted in a bracketed group, sitting in a
+    non-final path part, or unable to extend a marked episode list (a list grows rightwards from
+    its marker and stays glued to it, as in "E01 02 03") (#943).
+
+    Runs before anything is carved out of the name (rebulk executes rules by decreasing priority),
+    so the freed span goes back to the title instead of leaving a hole behind.
+    """
+
+    priority = PRE_PROCESS + 1
+    consequence = RemoveMatch
+
+    def enabled(self, context: dict[str, Any] | None) -> bool:
+        return bool(context and context.get("type") == "episode")
+
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        to_remove: list[Match] = []
+        fileparts = matches.markers.named("path")
+        for index, filepart in enumerate(fileparts):
+            episodes_ = sorted(
+                matches.range(filepart.start, filepart.end, predicate=lambda m: m.name == "episode"),
+                key=lambda m: (m.start, m.end),
+            )
+            in_final_part = index == len(fileparts) - 1
+            misplaced = [
+                episode
+                for episode in episodes_
+                if self._is_lone_digit(episode) and self._numbers_something_else(matches, episode, in_final_part)
+            ]
+            kept = [episode for episode in episodes_ if episode not in misplaced]
+            misplaced.extend(self._detached_from_list(kept))
+
+            for episode in misplaced:
+                to_remove.extend(self._whole_match(matches, episode))
+
+        return to_remove
+
+    @staticmethod
+    def _is_lone_digit(episode: Match) -> bool:
+        return "weak-episode" in episode.tags and len(episode.raw or "") == 1
+
+    @staticmethod
+    def _numbers_something_else(matches: Matches, episode: Match, in_final_part: bool) -> bool:
+        """A digit numbering a parent directory ("/Volumes/data-1/…") or a quoted group ("[t.3.3.d]")."""
+        quoted = matches.markers.at_match(episode, lambda marker: marker.name == "group", 0)
+        return not in_final_part or bool(quoted)
+
+    @classmethod
+    def _detached_from_list(cls, episodes_: list[Match]) -> list[Match]:
+        """Lone digits that cannot extend the marked episode list of their filepart."""
+        anchor = next((episode for episode in episodes_ if "weak-episode" not in episode.tags), None)
+        if anchor is None:
+            return []
+
+        detached: list[Match] = []
+        previous = anchor
+        for episode in episodes_:
+            if episode.end <= anchor.start:
+                if cls._is_lone_digit(episode):
+                    detached.append(episode)
+                continue
+
+            between = (episode.input_string or "")[previous.end : episode.start].strip(seps)
+            if between and cls._is_lone_digit(episode):
+                detached.append(episode)
+            else:
+                previous = episode
+
+        return detached
+
+    @staticmethod
+    def _whole_match(matches: Matches, episode: Match) -> list[Match]:
+        """The match and the private ones holding its span, so the freed text becomes a hole again."""
+        return matches.range(
+            episode.start,
+            episode.end,
+            predicate=lambda m: "weak-episode" in m.tags and m.start >= episode.start and m.end <= episode.end,
+        )
 
 
 class RemoveWeakIfSxxExx(Rule):

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -771,17 +771,29 @@ class CountValidator(Rule):
         season_count: list[Match] = []
 
         for count in matches.named("count"):
-            previous = matches.previous(count, lambda match: match.name in ["episode", "season"], 0)
-            if previous:
-                if previous.name == "episode":
-                    episode_count.append(count)
-                elif previous.name == "season":
-                    season_count.append(count)
-            else:
+            numbered = self._numbered_by(matches, count)
+            if numbered is None:
                 to_remove.append(count)
+            elif numbered.name == "episode":
+                episode_count.append(count)
+            else:
+                season_count.append(count)
         if to_remove or episode_count or season_count:
             return to_remove, episode_count, season_count
         return False
+
+    @staticmethod
+    def _numbered_by(matches: Matches, count: Match) -> Match | None:
+        """The episode or season the count belongs to: the last one its own match holds.
+
+        Scoped to the count's match rather than to the nearest neighbour, because another property
+        can sit on the linking word itself — "de" is the German language code as much as it is the
+        Spanish "of" — and would then hide the number the count completes.
+        """
+        numbers = matches.range(
+            count.initiator.start, count.start, predicate=lambda match: match.name in ("episode", "season")
+        )
+        return numbers[-1] if numbers else None
 
 
 class SeePatternRange(Rule):

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -416,8 +416,12 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         disabled=lambda context: context.get("type") == "episode" or is_disabled(context, "episode"),
     )
 
+    # A roman numeral can be read out of the letters a longer marker continues with ("Ep" then
+    # "i" of "Episodio"), so the marker only counts when it ends on a word boundary. The digit
+    # variant above needs no such guard: a letter can never start its number.
     rebulk.regex(
         build_or_pattern(episode_words, name="episodeMarker")
+        + r"(?![^\W\d_])"
         + r"-?-?(?:(?:№|#)-?)?(?P<episode>"
         + numeral
         + ")"

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -382,13 +382,16 @@ def episodes(config: dict[str, Any]) -> Rebulk:
 
     # Non-English convention where the number precedes the keyword:
     #   "1ª Temporada", "3 сезон", "5-й сезон", "2.Sezon" (season); "24 серия", "7.Bölüm" (episode).
-    # An optional ordinal suffix (ª/º/°, Portuguese a/o, Russian -й/-я/…) may sit between the two.
+    # An optional ordinal suffix (ª/º/°, Portuguese a/o, Russian -й/-я/…) may sit between the two,
+    # and the total may follow the keyword ("5 серия из 12"), as it does in the word-first patterns.
+    of_count = r"(?:@?" + build_or_pattern(of_words) + r"@?(?P<count>\d+))?"
     rebulk.regex(
         r"(?P<season>\d{1,2})"
         + ordinal_suffix
         + r"@?@?"
         + build_or_pattern(season_words_numfirst, name="seasonMarker")
-        + r"(?![^\W\d_])",
+        + r"(?![^\W\d_])"
+        + of_count,
         tags=["SxxExx", "numfirst"],
         formatter={"season": parse_numeral},
         disabled=is_season_episode_disabled,
@@ -398,7 +401,8 @@ def episodes(config: dict[str, Any]) -> Rebulk:
         + ordinal_suffix
         + r"@?@?"
         + build_or_pattern(episode_words_numfirst, name="episodeMarker")
-        + r"(?![^\W\d_])",
+        + r"(?![^\W\d_])"
+        + of_count,
         tags=["SxxExx", "numfirst"],
         formatter={"episode": parse_numeral},
         disabled=lambda context: is_disabled(context, "episode"),

--- a/guessit/rules/properties/episodes.py
+++ b/guessit/rules/properties/episodes.py
@@ -1103,8 +1103,9 @@ class RemoveMisleadingLoneDigitEpisode(Rule):
     wherever a digit sits — including inside a release group, in a parent directory, or in the
     tail of a title — where it then evicts whatever owned that span. Such a digit is discarded
     when it cannot be part of the episode numbering: quoted in a bracketed group, sitting in a
-    non-final path part, or unable to extend a marked episode list (a list grows rightwards from
-    its marker and stays glued to it, as in "E01 02 03") (#943).
+    non-final path part, behind the dot of a decimal number, or unable to extend a marked episode
+    list (a list grows rightwards from its marker and stays glued to it, as in "E01 02 03")
+    (#943, #948).
 
     Runs before anything is carved out of the name (rebulk executes rules by decreasing priority),
     so the freed span goes back to the title instead of leaving a hole behind.
@@ -1128,7 +1129,10 @@ class RemoveMisleadingLoneDigitEpisode(Rule):
             misplaced = [
                 episode
                 for episode in episodes_
-                if self._is_lone_digit(episode) and self._numbers_something_else(matches, episode, in_final_part)
+                if self._is_lone_digit(episode)
+                and (
+                    self._numbers_something_else(matches, episode, in_final_part) or self._fraction_of_a_number(episode)
+                )
             ]
             kept = [episode for episode in episodes_ if episode not in misplaced]
             misplaced.extend(self._detached_from_list(kept))
@@ -1147,6 +1151,12 @@ class RemoveMisleadingLoneDigitEpisode(Rule):
         """A digit numbering a parent directory ("/Volumes/data-1/…") or a quoted group ("[t.3.3.d]")."""
         quoted = matches.markers.at_match(episode, lambda marker: marker.name == "group", 0)
         return not in_final_part or bool(quoted)
+
+    @staticmethod
+    def _fraction_of_a_number(episode: Match) -> bool:
+        """A digit behind the dot of a decimal number ("02.5"): a half episode, not a second one."""
+        before = (episode.input_string or "")[: episode.start]
+        return len(before) > 1 and before[-1] == "." and before[-2].isdigit()
 
     @classmethod
     def _detached_from_list(cls, episodes_: list[Match]) -> list[Match]:

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -150,6 +150,9 @@ def complete_words(
 ) -> None:
     """
     Custom pattern to find complete seasons from words.
+
+    ``season_number_separators`` are the tokens that may join the season numbers a marker spans,
+    e.g. the ``&`` of "Seasons 1 & 2 - Complete"; plain separators are always allowed.
     """
     season_words_pattern = build_or_pattern(season_words)
     complete_article_words_pattern = build_or_pattern(complete_article_words)

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -142,12 +142,19 @@ def opening_ending_credits(rebulk: Rebulk) -> None:
     add(r"ED", "Ending Credits", ignore_case=False)
 
 
-def complete_words(rebulk: Rebulk, season_words: Iterable[str], complete_article_words: Iterable[str]) -> None:
+def complete_words(
+    rebulk: Rebulk,
+    season_words: Iterable[str],
+    complete_article_words: Iterable[str],
+    season_number_separators: Iterable[str],
+) -> None:
     """
     Custom pattern to find complete seasons from words.
     """
     season_words_pattern = build_or_pattern(season_words)
     complete_article_words_pattern = build_or_pattern(complete_article_words)
+    # The season numbers listed between the season word and the marker: "1", "1 & 2", "1 and 2".
+    season_numbers_pattern = r"(?:-+(?:\d+|" + build_or_pattern(season_number_separators, escape=True) + r"))+-+"
 
     def validate_complete(match: Match) -> bool:
         """
@@ -175,6 +182,20 @@ def complete_words(rebulk: Rebulk, season_words: Iterable[str], complete_article
         value={"other": "Complete"},
         tags=["release-group-prefix"],
         validator={"__parent__": and_(seps_surround, validate_complete)},
+    )
+
+    # "Season 1 Complete", "Seasons 1 & 2 - Complete": the season numbers sit between the season
+    # word and the marker, so the adjacency pattern above cannot see the word. Anchoring on the
+    # numbered season word keeps the marker alive even when nothing matched the numbers — the
+    # season chain is off under a forced ``type=movie`` (#944).
+    rebulk.regex(
+        season_words_pattern + season_numbers_pattern + "(?P<other>Complete)",
+        children=True,
+        private_parent=True,
+        validate_all=True,
+        value={"other": "Complete"},
+        tags=["release-group-prefix"],
+        validator={"__parent__": seps_surround},
     )
 
 

--- a/guessit/rules/properties/release_group.py
+++ b/guessit/rules/properties/release_group.py
@@ -140,13 +140,13 @@ def leading_anime_group(matches: Matches, filepart: Match) -> Match | None:
     return None
 
 
-_seps_class = "[" + re.escape(seps) + "]"
+_SEPS_CHARS = re.escape(seps)
 
 #: A trailing hole made of a numeric run and a final dash-separated word, e.g. ``.313-314-GROUP``.
 #: Digits and separators alone cannot be a title, so the last word stays a release group even when
 #: nothing claimed the numbers.
 _NUMERIC_RUN_THEN_GROUP = re.compile(
-    rf"^{_seps_class}?\d+(?:{_seps_class}+\d+)*-(?P<group>[^{re.escape(seps)}]{{2,}})$"
+    rf"^[{_SEPS_CHARS}]?\d+(?:[{_SEPS_CHARS}]+\d+)*-(?P<group>[^{_SEPS_CHARS}]{{2,}})$"
 )
 
 

--- a/guessit/rules/properties/release_group.py
+++ b/guessit/rules/properties/release_group.py
@@ -140,6 +140,16 @@ def leading_anime_group(matches: Matches, filepart: Match) -> Match | None:
     return None
 
 
+_seps_class = "[" + re.escape(seps) + "]"
+
+#: A trailing hole made of a numeric run and a final dash-separated word, e.g. ``.313-314-GROUP``.
+#: Digits and separators alone cannot be a title, so the last word stays a release group even when
+#: nothing claimed the numbers.
+_NUMERIC_RUN_THEN_GROUP = re.compile(
+    rf"^{_seps_class}?\d+(?:{_seps_class}+\d+)*-(?P<group>[^{re.escape(seps)}]{{2,}})$"
+)
+
+
 class DashSeparatedReleaseGroup(Rule):
     """
     Detect dash separated release groups that might appear at the end or at the beginning of a release name.
@@ -288,7 +298,34 @@ class DashSeparatedReleaseGroup(Rule):
 
         if candidate and self.is_valid(matches, candidate, start, end, at_end):
             return candidate
+        if at_end:
+            return self.detect_after_numeric_run(matches, start, end)
         return None
+
+    @classmethod
+    def detect_after_numeric_run(cls, matches: Matches, start: int, end: int) -> Match | None:
+        """
+        Detach a trailing dash separated group from an unclaimed numeric run.
+
+        ``Bleach.s16e03-04.313-314-GROUP`` leaves ``.313-314-GROUP`` as a single hole whenever no
+        rule claims the absolute episode run — the weak episode chains are off under a forced
+        ``type=movie`` (#944). The run is anchored on the season/episode markers it follows, so the
+        trailing word behind it is a release group rather than the tail of a title.
+        """
+        hole = matches.holes(start, end, index=-1, predicate=lambda m: m.end == end and m.raw)
+        if not hole or hole.raw is None:
+            return None
+
+        numeric_run = _NUMERIC_RUN_THEN_GROUP.match(hole.raw)
+        if not numeric_run or int_coercable(numeric_run.group("group")):
+            return None
+
+        previous = matches.range(start, hole.start, index=-1, predicate=lambda m: not m.private)
+        if not previous or previous.name not in ("season", "episode"):
+            return None
+
+        # The candidate keeps its leading dash, as the ones the branches above return do.
+        return Match(hole.start + numeric_run.start("group") - 1, hole.end, input_string=hole.input_string)
 
     def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
         if matches.named("release_group"):

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -503,8 +503,12 @@ class PreferTitleWithYear(Rule):
 
 class CountryAtTitlePosition(Rule):
     """
-    A Title-Case country/other word that starts the filepart and is immediately
-    followed by a year (only separators between) is really the title (upstream #638).
+    A Title-Case country/other word that starts the filepart and opens the title is really
+    part of the title, not a tag (upstream #638, #928).
+
+    It qualifies when the word is followed, before the next year/season/episode/date anchor,
+    by only separators ("Us.2019...") or by plain title text ("Au bout c'est la mer - 8x01").
+    Another property in that gap ("Us.1080p.S01E01") means the word is a genuine tag.
 
     The casing anchor is load-bearing: "Us" (Title-Case) is the title, but "US" (a real
     country tag) is kept, so "The.Office.(US).1x03" keeps country: US. An ``edition`` or a
@@ -532,18 +536,20 @@ class CountryAtTitlePosition(Rule):
                 continue
             if not all(ch in seps for ch in input_string[filepart.start : candidate.start]):
                 continue
-            year = matches.range(candidate.end, filepart.end, lambda m: not m.private and m.name == "year", 0)
-            if not year:
-                continue
-            if matches.range(
+            anchor = matches.range(
                 candidate.end,
-                year.start,
-                lambda m: not m.private and m.name in ("season", "episode", "date"),
+                filepart.end,
+                lambda m: not m.private and m.name in ("year", "season", "episode", "date"),
                 0,
-            ):
+            )
+            if not anchor:
                 continue
-            if not all(ch in seps for ch in input_string[candidate.end : year.start]):
-                continue
+            if not all(ch in seps for ch in input_string[candidate.end : anchor.start]):
+                # Plain title text between the leading word and the anchor means the word
+                # opens that title ("Au bout c'est la mer - 8x01"). Another property in the
+                # gap ("Us.1080p.S01E01") means the word is a real tag, not the title.
+                if matches.range(candidate.end, anchor.start, lambda m: not m.private and m.value, 0):
+                    continue
             to_remove.append(candidate)
         return to_remove
 

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -548,7 +548,7 @@ class CountryAtTitlePosition(Rule):
                 # Plain title text between the leading word and the anchor means the word
                 # opens that title ("Au bout c'est la mer - 8x01"). Another property in the
                 # gap ("Au.HDTV.8x01") means the word is a real tag, not the title.
-                if matches.range(candidate.end, anchor.start, lambda m: not m.private and m.value, 0):
+                if matches.range(candidate.end, anchor.start, lambda m: not m.private and m.value is not None, 0):
                     continue
             to_remove.append(candidate)
         return to_remove

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -508,7 +508,7 @@ class CountryAtTitlePosition(Rule):
 
     It qualifies when the word is followed, before the next year/season/episode/date anchor,
     by only separators ("Us.2019...") or by plain title text ("Au bout c'est la mer - 8x01").
-    Another property in that gap ("Us.1080p.S01E01") means the word is a genuine tag.
+    Another property in that gap ("Au.HDTV.8x01") means the word is a genuine tag.
 
     The casing anchor is load-bearing: "Us" (Title-Case) is the title, but "US" (a real
     country tag) is kept, so "The.Office.(US).1x03" keeps country: US. An ``edition`` or a
@@ -547,7 +547,7 @@ class CountryAtTitlePosition(Rule):
             if not all(ch in seps for ch in input_string[candidate.end : anchor.start]):
                 # Plain title text between the leading word and the anchor means the word
                 # opens that title ("Au bout c'est la mer - 8x01"). Another property in the
-                # gap ("Us.1080p.S01E01") means the word is a real tag, not the title.
+                # gap ("Au.HDTV.8x01") means the word is a real tag, not the title.
                 if matches.range(candidate.end, anchor.start, lambda m: not m.private and m.value, 0):
                     continue
             to_remove.append(candidate)

--- a/guessit/rules/properties/title.py
+++ b/guessit/rules/properties/title.py
@@ -317,8 +317,8 @@ class TitleBaseRule(Rule):
 
             if hole and hole.value:
                 hole.name = self.match_name
-                hole.tags = self.match_tags or []
-                if self.alternative_match_name:
+                hole.tags = list(self.match_tags or [])
+                if self.alternative_match_name and not is_disabled(context, self.alternative_match_name):
                     # Split and keep values that can be a title
                     titles = hole.split(title_seps, lambda m: m.value)
                     for title_match in list(titles[1:]):
@@ -451,9 +451,6 @@ class TitleFromPosition(TitleBaseRule):
 
     def __init__(self) -> None:
         super().__init__("title", ["title"], "alternative_title")
-
-    def enabled(self, context: dict[str, Any] | None) -> bool:
-        return not is_disabled(context, "alternative_title")
 
 
 class PreferTitleWithYear(Rule):

--- a/guessit/test/enable_disable_properties.yml
+++ b/guessit/test/enable_disable_properties.yml
@@ -254,6 +254,11 @@
 : options: --exclude title
   -title: Title Only
 
+? Star Wars - The Mandalorian and Grogu (2026) 720p x265.mkv
+: options: --exclude alternative_title
+  title: Star Wars - The Mandalorian and Grogu
+  -alternative_title: The Mandalorian and Grogu
+
 ? h265
 ? x265
 ? h.265

--- a/guessit/test/enable_disable_properties.yml
+++ b/guessit/test/enable_disable_properties.yml
@@ -259,6 +259,10 @@
   title: Star Wars - The Mandalorian and Grogu
   -alternative_title: The Mandalorian and Grogu
 
+? Some.Movie.2019.1080p.BluRay.x264-GRP.mkv
+: options: --include title
+  title: Some Movie 2019 1080p BluRay x264-GRP mkv
+
 ? h265
 ? x265
 ? h.265

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -1038,6 +1038,62 @@
   video_codec: H.264
   year: 2013
 
+# The word linking a number to its total, in the languages the markers already cover.
+? Show.Name.Capitulo.5.de.12.HDTV.x264-GRUPO
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  source: HDTV
+  video_codec: H.264
+  release_group: GRUPO
+
+? Serie.Temporada.1.de.5.1080p.WEB-DL
+: title: Serie
+  season: 1
+  season_count: 5
+  screen_size: 1080p
+  source: Web
+
+? Show.Name.Episodio.5.di.12.ITA.1080p.BluRay
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  language: it
+  screen_size: 1080p
+  source: Blu-ray
+
+? Show.Name.Stagione.1.di.5.720p
+: title: Show Name
+  season: 1
+  season_count: 5
+  screen_size: 720p
+
+? Show.Name.Folge.5.von.12.German.HDTV
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  language: de
+  source: HDTV
+
+? Show.Name.Aflevering.5.van.12.1080p
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  screen_size: 1080p
+
+? Show.Name.Episodul.5.din.12.HDTV
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  source: HDTV
+
+# "av" is left out of the of-words: it would read the AV1 codec as a total (#950).
+? Show.Name.Season.2.AV1.1080p
+: title: Show Name
+  season: 2
+  screen_size: 1080p
+  -season_count: 1
+
 ? Something.S04E05E09
 : episode: # 1.x guessit this as a range from 5 to 9. But not sure if it should ...
   - 5

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5372,3 +5372,18 @@
   episode: 3
   video_codec: H.264
   -season: 3
+
+# A leading country-code word that opens the title is the title, not a country tag (#928)
+? Au.bout.c'est.la.mer.-.8x01.-.Le.fleuve.Yukon.mp4
+: title: Au bout c'est la mer
+  season: 8
+  episode: 1
+  episode_title: Le fleuve Yukon
+  -country: AU
+
+? Au bout c'est la mer - 8x01 - Le fleuve Yukon.mp4
+: title: Au bout c'est la mer
+  season: 8
+  episode: 1
+  episode_title: Le fleuve Yukon
+  -country: AU

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -1087,6 +1087,14 @@
   episode_count: 12
   source: HDTV
 
+# Russian numbers its episode before the marker, and its total after it.
+? Show.Name.5.серия.из.12.WEB-DL.1080p
+: title: Show Name
+  episode: 5
+  episode_count: 12
+  source: Web
+  screen_size: 1080p
+
 # "av" is left out of the of-words: it would read the AV1 codec as a total (#950).
 ? Show.Name.Season.2.AV1.1080p
 : title: Show Name

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -5387,3 +5387,19 @@
   episode: 1
   episode_title: Le fleuve Yukon
   -country: AU
+
+# guard: a property between the leading word and the anchor means the word is a real tag
+? Au.HDTV.8x01.Le.fleuve.mkv
+: country: AU
+  source: HDTV
+  season: 8
+  episode: 1
+  title: Le fleuve
+
+# trade-off of accepting title text before the anchor: a genuine country tag followed by
+# plain title text is now read as the opening word of that title
+? Uk.Top.Gear.S01E01.mkv
+: title: Uk Top Gear
+  season: 1
+  episode: 1
+  -country: GB

--- a/guessit/test/test_api.py
+++ b/guessit/test/test_api.py
@@ -97,6 +97,34 @@ def test_list_value_not_mutated_between_guesses() -> None:
     assert guessit("ultimate collector edition")["edition"] == ["Ultimate", "Collector"]
 
 
+def test_title_rule_tags_not_mutated_between_guesses() -> None:
+    """
+    The tags TitleFromPosition puts on the title hole must be a copy of the rule's own list.
+
+    The rule instance lives in the cached rebulk and is shared by every guessit() call. When the
+    hole aliases ``match_tags`` instead of copying it, ``PreferTitleWithYear`` (which appends
+    ``equivalent-ignore`` to the title matches it demotes) extends that shared list in place, so
+    it grows at every parse and every later title is born already tagged ``equivalent-ignore`` --
+    a tag the processors act upon. A yaml corpus entry cannot catch this: each entry parses a
+    single string, while the leak only shows up on the parses that follow.
+    """
+    from ..rules.properties.title import TitleFromPosition
+
+    api.reset()
+    options = {"excludes": ["alternative_title"]}
+    for _ in range(3):
+        assert guessit("Movies/Foo (2019)/Foo.2019.1080p.BluRay.x264-GRP.mkv", options)["title"] == "Foo"
+
+    assert default_api.rebulk is not None
+    title_rule = next(
+        rule
+        for rule in default_api.rebulk.effective_rules(default_api.effective_options)
+        if isinstance(rule, TitleFromPosition)
+    )
+    assert title_rule.match_tags == ["title"]
+    api.reset()
+
+
 def test_exception() -> None:
     with pytest.raises(GuessitException) as excinfo:
         guessit(object())  # type: ignore[arg-type]

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -21,12 +21,11 @@ from . import test_yml
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 # Names whose forced-type result still differs from the inferred one: a half-episode number
-# (02.5) and an episode word the numeral pattern leaves dangling. Tracked by #948; entries
-# must be removed as they get fixed.
+# (02.5) whose fractional digit the forced patterns read as a second episode. Tracked by #948;
+# entries must be removed as they get fixed.
 KNOWN_DIVERGENCES = frozenset(
     {
         "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]",
-        "La Casa di Carta Stagione 2 Episodio 5",
     }
 )
 
@@ -87,6 +86,23 @@ def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict
     result = guessit(name, {"type": "episode"})
     for prop, value in expected.items():
         assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "La Casa di Carta Stagione 2 Episodio 5",
+        "Show Name Episodio 5",
+        "Show Name Episodios 5",
+        "Show Name Capitulos 5",
+        "Show Name Episodul 5",
+    ],
+)
+def test_forced_episode_consumes_the_whole_episode_word(name: str) -> None:
+    """The numeral variant claims its marker instead of a shorter one a roman numeral extends (#948)."""
+    result = guessit(name, {"type": "episode"})
+    assert result.get("episode") == 5
+    assert "episode_title" not in result
 
 
 @pytest.mark.parametrize(

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -15,6 +15,8 @@ import pytest
 import yaml
 
 from .. import guessit
+from ..options import load_config
+from ..rules.properties.episodes import _split_words
 from ..yamlutils import OrderedDictYAMLLoader
 from . import test_yml
 
@@ -73,21 +75,29 @@ def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict
         assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
 
 
-@pytest.mark.parametrize(
-    "name",
-    [
-        "La Casa di Carta Stagione 2 Episodio 5",
-        "Show Name Episodio 5",
-        "Show Name Episodios 5",
-        "Show Name Capitulos 5",
-        "Show Name Episodul 5",
-    ],
-)
-def test_forced_episode_consumes_the_whole_episode_word(name: str) -> None:
-    """The numeral variant claims its marker instead of a shorter one a roman numeral extends (#948)."""
-    result = guessit(name, {"type": "episode"})
-    assert result.get("episode") == 5
-    assert "episode_title" not in result
+def marker_names(word_key: str) -> list[str]:
+    """One "Show Name <marker> 5" per configured season/episode word, reversed for number-first ones."""
+    config = load_config({"no_user_config": True})["advanced_config"]["episodes"]
+    words, numfirst = _split_words(config[word_key])
+    return [f"Show Name 5 {word}" if word in set(numfirst) else f"Show Name {word} 5" for word in words]
+
+
+@pytest.mark.parametrize("options", [{}, {"type": "episode"}], ids=["inferred", "forced"])
+@pytest.mark.parametrize("name", marker_names("episode_words"))
+def test_every_episode_word_is_claimed_by_its_number(name: str, options: dict[str, str]) -> None:
+    """A marker is claimed whole: a shorter one leaving its tail in the title is the #948 bug."""
+    result = guessit(name, options)
+    assert result.get("episode") == 5, f"episode: {dict(result)}"
+    assert result.get("title") == "Show Name", f"title: {dict(result)}"
+
+
+@pytest.mark.parametrize("options", [{}, {"type": "episode"}], ids=["inferred", "forced"])
+@pytest.mark.parametrize("name", marker_names("season_words"))
+def test_every_season_word_is_claimed_by_its_number(name: str, options: dict[str, str]) -> None:
+    """Same guard on the season side, where the numeral pattern is shared by both modes."""
+    result = guessit(name, options)
+    assert result.get("season") == 5, f"season: {dict(result)}"
+    assert result.get("title") == "Show Name", f"title: {dict(result)}"
 
 
 @pytest.mark.parametrize(

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -20,19 +20,13 @@ from . import test_yml
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
-# Names whose forced-type result still differs from the inferred one. Each is a lone digit that
-# only the forced-episode patterns pick up — inside a release group, a path segment or a duplicate
-# marker — and pushes out a property. Tracked by #943; entries must be removed as they get fixed.
+# Names whose forced-type result still differs from the inferred one: a half-episode number
+# (02.5) and an episode word the numeral pattern leaves dangling. Tracked by #948; entries
+# must be removed as they get fixed.
 KNOWN_DIVERGENCES = frozenset(
     {
-        "series/Freaks And Geeks/Season 1/Episode 4 - Kim Kelly Is My Friend-eng(1).srt",
-        "/Volumes/data-1/Series/Futurama/Season 3/Futurama_-_S03_DVD_Bonus_-_Deleted_Scenes_Part_3.ogm",
-        "[t.3.3.d]_Mikakunin_de_Shinkoukei_-_12_[720p][5DDC1352].mkv",
-        "[7.1.7.8.5] Foo Bar - 11 (H.264) [5235532D].mkv",
         "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]",
-        "Thumping.Spike.2.E01.DF.WEBRip.720p-DRAMATV.mp4",
         "La Casa di Carta Stagione 2 Episodio 5",
-        "GTTV.E3.All.Access.Live.Day.1.Xbox.Showcase.Preshow.HDTV.x264-SYS",
     }
 )
 
@@ -100,3 +94,33 @@ def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
     result = guessit("Series/Episode/12.Angry.Men.1957.mkv", {"type": "episode"})
     assert result.get("title") == "12 Angry Men"
     assert result.get("year") == 1957
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # A lone digit only the forced-episode patterns see must not evict what owns its span:
+        # the tail of a title, a word of the episode title, a duplicate suffix, a release group,
+        # or a parent directory (#943).
+        ("Thumping.Spike.2.E01.DF.WEBRip.720p-DRAMATV.mp4", {"title": "Thumping Spike 2", "episode": 1}),
+        (
+            "GTTV.E3.All.Access.Live.Day.1.Xbox.Showcase.Preshow.HDTV.x264-SYS",
+            {"episode": 3, "episode_title": "All Access Live Day 1 Xbox Showcase Preshow"},
+        ),
+        ("[t.3.3.d]_Mikakunin_de_Shinkoukei_-_12_[720p][5DDC1352].mkv", {"episode": 12, "release_group": "t.3.3.d"}),
+        ("[7.1.7.8.5] Foo Bar - 11 (H.264) [5235532D].mkv", {"episode": 11, "release_group": "7.8.5"}),
+        (
+            "/Volumes/data-1/Series/Futurama/Season 3/Futurama_-_S03_DVD_Bonus_-_Deleted_Scenes_Part_3.ogm",
+            {"title": "Futurama", "season": 3},
+        ),
+        # A number that does carry the episode numbering stays, marked or not.
+        ("Some Series E01 02 03", {"episode": [1, 2, 3]}),
+        ("Show.Name.Season.4.Episodes.1-12", {"season": 4, "episode": list(range(1, 13))}),
+        ("FooBar.7.PDTV-FlexGet", {"episode": 7}),
+        ("Show Name - 313-315 - s16e03-05", {"absolute_episode": [313, 314, 315], "episode": [3, 4, 5]}),
+    ],
+)
+def test_forced_episode_keeps_a_lone_digit_out_of_other_properties(name: str, expected: dict[str, object]) -> None:
+    result = guessit(name, {"type": "episode"})
+    for prop, value in expected.items():
+        assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -103,6 +103,9 @@ def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict
         ("Series/Mad Men Season 1 Complete/Mad.Men.S01E01.avi", {"title": "Mad Men", "other": "Complete"}),
         ("Something Seasons 1 & 2 - Complete", {"title": "Something", "other": "Complete"}),
         ("Something Seasons 4 Complete", {"title": "Something", "other": "Complete"}),
+        # An absolute episode run nothing claims must not swallow the trailing release group.
+        ("Bleach.s16e03-04.313-314-GROUP", {"title": "Bleach", "release_group": "GROUP"}),
+        ("Show.Name.16x03-05.313-315-GROUP", {"title": "Show Name", "release_group": "GROUP"}),
     ],
 )
 def test_forced_movie_keeps_properties_unrelated_to_episodes(name: str, expected: dict[str, object]) -> None:

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -22,7 +22,7 @@ __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file
 
 # Names whose forced-type result still differs from the inferred one. Each is a lone digit that
 # only the forced-episode patterns pick up — inside a release group, a path segment or a duplicate
-# marker — and pushes out a property. Tracked by #939; entries must be removed as they get fixed.
+# marker — and pushes out a property. Tracked by #943; entries must be removed as they get fixed.
 KNOWN_DIVERGENCES = frozenset(
     {
         "series/Freaks And Geeks/Season 1/Episode 4 - Kim Kelly Is My Friend-eng(1).srt",

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -114,6 +114,19 @@ def test_forced_movie_keeps_properties_unrelated_to_episodes(name: str, expected
         assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
 
 
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Show.Name.2019.313-314-GROUP",
+        "Show Name 313-314-GROUP",
+        "12-Monkeys",
+    ],
+)
+def test_a_numeric_run_alone_does_not_yield_a_release_group(name: str) -> None:
+    """Only a run anchored on a season/episode marker vouches for the word behind it (#944)."""
+    assert "release_group" not in guessit(name, {"type": "movie"})
+
+
 def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
     """A parent directory named "Episode" must not vouch for a number in the file below it."""
     result = guessit("Series/Episode/12.Angry.Men.1957.mkv", {"type": "episode"})

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -20,15 +20,6 @@ from . import test_yml
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
-# Names whose forced-type result still differs from the inferred one: a half-episode number
-# (02.5) whose fractional digit the forced patterns read as a second episode. Tracked by #948;
-# entries must be removed as they get fixed.
-KNOWN_DIVERGENCES = frozenset(
-    {
-        "[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]",
-    }
-)
-
 
 def corpus_names() -> list[str]:
     """Every input string of the yaml corpus, minus the entries pinned to their own options."""
@@ -47,9 +38,8 @@ def corpus_names() -> list[str]:
 
 
 def test_forcing_the_inferred_type_is_a_no_op() -> None:
-    names = corpus_names()
     divergences = {}
-    for name in names:
+    for name in corpus_names():
         inferred = guessit(name)
         guessed_type = inferred.get("type")
         if guessed_type not in ("movie", "episode"):
@@ -58,14 +48,9 @@ def test_forcing_the_inferred_type_is_a_no_op() -> None:
         if dict(forced) != dict(inferred):
             divergences[name] = (dict(inferred), dict(forced))
 
-    unexpected = {name: diff for name, diff in divergences.items() if name not in KNOWN_DIVERGENCES}
-    assert not unexpected, "forcing the inferred type changed the result:\n" + "\n".join(
-        f"  {name}\n    inferred={inferred}\n    forced  ={forced}" for name, (inferred, forced) in unexpected.items()
+    assert not divergences, "forcing the inferred type changed the result:\n" + "\n".join(
+        f"  {name}\n    inferred={inferred}\n    forced  ={forced}" for name, (inferred, forced) in divergences.items()
     )
-
-    scanned = set(names)
-    stale = {name for name in KNOWN_DIVERGENCES if name in scanned and name not in divergences}
-    assert not stale, f"these names no longer diverge, drop them from KNOWN_DIVERGENCES: {sorted(stale)}"
 
 
 @pytest.mark.parametrize(
@@ -166,6 +151,9 @@ def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
         ("Show.Name.Season.4.Episodes.1-12", {"season": 4, "episode": list(range(1, 13))}),
         ("FooBar.7.PDTV-FlexGet", {"episode": 7}),
         ("Show Name - 313-315 - s16e03-05", {"absolute_episode": [313, 314, 315], "episode": [3, 4, 5]}),
+        # The fractional digit of a half episode is not a second episode (#948).
+        ("[GroupName].Show.Name.-.02.5.(Special).[BD.1080p]", {"episode": 2, "episode_title": "5"}),
+        ("Show.Name.-.12.5.(Special)", {"episode": 12, "episode_title": "5"}),
     ],
 )
 def test_forced_episode_keeps_a_lone_digit_out_of_other_properties(name: str, expected: dict[str, object]) -> None:

--- a/guessit/test/test_forced_type.py
+++ b/guessit/test/test_forced_type.py
@@ -95,6 +95,22 @@ def test_forced_episode_keeps_year_anchored_properties(name: str, expected: dict
         assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
 
 
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # The "Complete" marker is anchored on the numbered season word, so it survives the season
+        # chain being off (#944).
+        ("Series/Mad Men Season 1 Complete/Mad.Men.S01E01.avi", {"title": "Mad Men", "other": "Complete"}),
+        ("Something Seasons 1 & 2 - Complete", {"title": "Something", "other": "Complete"}),
+        ("Something Seasons 4 Complete", {"title": "Something", "other": "Complete"}),
+    ],
+)
+def test_forced_movie_keeps_properties_unrelated_to_episodes(name: str, expected: dict[str, object]) -> None:
+    result = guessit(name, {"type": "movie"})
+    for prop, value in expected.items():
+        assert result.get(prop) == value, f"{prop}: {result.get(prop)!r} != {value!r} in {dict(result)}"
+
+
 def test_forced_episode_ignores_an_episode_word_from_another_filepart() -> None:
     """A parent directory named "Episode" must not vouch for a number in the file below it."""
     result = guessit("Series/Episode/12.Angry.Men.1957.mkv", {"type": "episode"})


### PR DESCRIPTION
Release of everything merged into `develop` since v4.2.1 — 9 parsing fixes and one new capability,
so semantic-release computes **v4.3.0**.

### Features

- **episodes**: read the total that follows a number-first marker (`5 серия из 12`)

### Bug Fixes

- **episodes**: know the "of" word of the languages the markers cover (#950)
- **episodes**: keep the fraction of a half episode out of the numbering (#948)
- **episodes**: claim the whole episode word before a roman numeral (#948)
- **episodes**: drop a lone digit that plainly numbers something else (#946)
- **title**: keep the title when `alternative_title` is excluded
- **title**: keep a leading country word that opens the title (#928)
- **title**: count a falsy-valued match as a property in the gap
- **release_group**: keep a trailing group out of an unclaimed numeric run
- **other**: anchor the Complete marker on the numbered season word

### Before merging

**Merge as a merge commit, never squash** — squashing collapses the commit bodies semantic-release
reads to compute the bump.

The version was dry-run on a throwaway `main` (`semantic-release version --print`): **4.3.0**, and
the changelog section generates correctly under the `<!-- version list -->` marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxY6td16TcG8HYCQAnBezP