### PR TITLE
feat(other): read the French INTEGRALE as a complete run

### DIFF
--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -560,7 +560,10 @@
         "Full HD": {"string": ["FHD"],"regex": ["Full-?HD"], "validator": null, "tags": ["streaming_service.prefix", "streaming_service.suffix"]},
         "Ultra HD": {"string": ["UHD"],"regex": ["Ultra-?(?:HD)?"], "validator": null, "tags": ["streaming_service.prefix", "streaming_service.suffix"]},
         "Upscaled": {"regex": "Upscaled?"},
-        "Complete": {"string": ["Complet", "Complete"], "tags": ["has-neighbor", "release-group-prefix"]},
+        "Complete": [
+          {"string": ["Complet", "Complete"], "tags": ["has-neighbor", "release-group-prefix"]},
+          {"regex": ["Int[ée]grale"], "tags": ["has-neighbor", "release-group-prefix"]}
+        ],
         "Classic": {"string": "Classic", "tags": ["has-neighbor", "release-group-prefix"]},
         "Bonus": {"string": "Bonus", "tags": ["has-neighbor", "release-group-prefix"]},
         "Trailer": {"string": "Trailer", "tags": ["has-neighbor", "release-group-prefix"]},
@@ -594,7 +597,7 @@
         "Proof": {"string": "Proof", "tags": ["at-end", "not-a-release-group"]},
         "Obfuscated": {"string": ["Obfuscated", "Scrambled"], "tags": ["at-end", "not-a-release-group"]},
         "Repost": {"string": ["xpost", "postbot", "asrequested"], "tags": "not-a-release-group"},
-        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "season_words": ["seasons?", "series?"], "complete_article_words": ["The"], "season_number_separators": ["&", "and"]}
+        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "complete_marker_words": ["Complete", "Int[ée]grale"], "season_words": ["seasons?", "series?"], "complete_article_words": ["The"], "complete_prefix_words": ["L['’]?", "Coffret"], "season_number_separators": ["&", "and"]}
       },
       "art": {
         "poster": "Poster",

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -151,16 +151,23 @@ _TOKEN_START = r"(?<![^\W_])"
 
 def complete_words(
     rebulk: Rebulk,
+    complete_marker_words: Iterable[str],
     season_words: Iterable[str],
     complete_article_words: Iterable[str],
+    complete_prefix_words: Iterable[str],
     season_number_separators: Iterable[str],
 ) -> None:
     """
     Custom pattern to find complete seasons from words.
 
-    ``season_number_separators`` are the tokens that may join the season numbers a marker spans,
-    e.g. the ``&`` of "Seasons 1 & 2 - Complete"; plain separators are always allowed.
+    ``complete_marker_words`` are the completeness markers themselves, ``Complete`` and its
+    equivalents in other languages. ``complete_article_words`` only qualify a marker that a season
+    word already anchors ("The Complete Series"), whereas ``complete_prefix_words`` carry the
+    completeness on their own ("L'Intégrale", "Coffret Intégrale"). ``season_number_separators``
+    are the tokens that may join the season numbers a marker spans, e.g. the ``&`` of
+    "Seasons 1 & 2 - Complete"; plain separators are always allowed.
     """
+    complete_marker_pattern = build_or_pattern(complete_marker_words)
     season_words_pattern = build_or_pattern(season_words)
     complete_article_words_pattern = build_or_pattern(complete_article_words)
     # The season numbers listed between the season word and the marker: "1", "1 & 2", "1 and 2".
@@ -185,7 +192,7 @@ def complete_words(
         + "(?P<completeWordsBefore>"
         + season_words_pattern
         + "-)?"
-        + "Complete"
+        + complete_marker_pattern
         + "(?P<completeWordsAfter>-"
         + season_words_pattern
         + ")?",
@@ -200,10 +207,26 @@ def complete_words(
     # numbered season word keeps the marker alive even when nothing matched the numbers — the
     # season chain is off under a forced ``type=movie`` (#944).
     rebulk.regex(
-        season_words_pattern + season_numbers_pattern + "(?P<other>Complete)",
+        season_words_pattern + season_numbers_pattern + "(?P<other>" + complete_marker_pattern + ")",
         children=True,
         private_parent=True,
         validate_all=True,
+        value={"other": "Complete"},
+        tags=["release-group-prefix"],
+        validator={"__parent__": seps_surround},
+    )
+
+    # "L'Intégrale", "Coffret Intégrale": the prefix carries the completeness with no season word
+    # to anchor on, so the first pattern rejects it. The separator is optional because the French
+    # elided article glues to the marker — the apostrophe is not a separator, so "L'Intégrale" is
+    # a single token that has to be matched whole for the marker to leave the title.
+    rebulk.regex(
+        _TOKEN_START
+        + "(?P<completePrefix>"
+        + build_or_pattern(complete_prefix_words)
+        + "-?)"
+        + complete_marker_pattern,
+        private_names=["completePrefix"],
         value={"other": "Complete"},
         tags=["release-group-prefix"],
         validator={"__parent__": seps_surround},

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -142,6 +142,13 @@ def opening_ending_credits(rebulk: Rebulk) -> None:
     add(r"ED", "Ending Credits", ignore_case=False)
 
 
+#: A match may only start on a token boundary. Without it a leading word part is a valid starting
+#: point for the regex — the "the" of "Breathe.Complete.Series" opens an article group — and the
+#: whole match is then dropped by ``seps_surround``, taking the real marker down with it: the
+#: scan resumes *after* the rejected span, so "Complete.Series" is never tried.
+_TOKEN_START = r"(?<![^\W_])"
+
+
 def complete_words(
     rebulk: Rebulk,
     season_words: Iterable[str],
@@ -171,7 +178,8 @@ def complete_words(
         return not (not children.named("completeWordsBefore") and not children.named("completeWordsAfter"))
 
     rebulk.regex(
-        "(?P<completeArticle>"
+        _TOKEN_START
+        + "(?P<completeArticle>"
         + complete_article_words_pattern
         + "-)?"
         + "(?P<completeWordsBefore>"

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2030,6 +2030,42 @@
   type: movie # Should be episode
   video_codec: Xvid
 
+? Friends.INTEGRALE.MULTi.1080p.BluRay-GRP
+? Friends.INTÉGRALE.MULTi.1080p.BluRay-GRP
+: title: Friends
+  other: Complete
+  language: mul
+  screen_size: 1080p
+  source: Blu-ray
+  release_group: GRP
+  type: movie # Should be episode, see #953
+
+? Malcolm.LIntegrale.FRENCH.DVDRip-GRP
+? Malcolm.L'Integrale.FRENCH.DVDRip-GRP
+: title: Malcolm
+  other: [Complete, Rip]
+  language: French
+  source: DVD
+  release_group: GRP
+  type: movie # Should be episode, see #953
+
+? Engrenages.Coffret.Integrale.FRENCH.1080p-GRP
+: title: Engrenages
+  other: Complete
+  language: French
+  screen_size: 1080p
+  release_group: GRP
+  type: movie # Should be episode, see #953
+
+? Breaking.Bad.INTEGRALE.Saison.1.FRENCH.1080p-GRP
+: title: Breaking Bad
+  other: Complete
+  season: 1
+  language: French
+  screen_size: 1080p
+  release_group: GRP
+  type: episode
+
 ? Show Name The Complete Seasons 1 to 5 720p BluRay x265 HEVC-SUJAIDR[UTR]
 : source: Blu-ray
   other: Complete

--- a/guessit/test/rules/other.yml
+++ b/guessit/test/rules/other.yml
@@ -134,6 +134,15 @@
 ? +The complete movie
 : title: The complete movie
 
+? INTEGRALE 1080p
+? INTÉGRALE 1080p
+? Integrale 1080p
+? L'Integrale 1080p
+? LIntegrale 1080p
+? L.Integrale.1080p
+? Coffret Integrale 1080p
+: other: Complete
+
 # A leading word part must not open the article group: the "the" of "Breathe" used to swallow
 # the whole match, and the marker went down with it.
 ? Breathe.Complete.Series.1080p-GRP

--- a/guessit/test/rules/other.yml
+++ b/guessit/test/rules/other.yml
@@ -134,6 +134,12 @@
 ? +The complete movie
 : title: The complete movie
 
+# A leading word part must not open the article group: the "the" of "Breathe" used to swallow
+# the whole match, and the marker went down with it.
+? Breathe.Complete.Series.1080p-GRP
+: other: Complete
+  title: Breathe
+
 ? +AC3-HQ
 : audio_profile: High Quality
 


### PR DESCRIPTION
Closes #954.

`INTEGRALE` is what French releases call a complete run — the direct equivalent of `COMPLETE`.
guessit did not know the word, so no `other: Complete` was emitted and the marker stayed inside
the title, which splits one show into two keys for any consumer keying on the title.

| name | `title` before | `title` after | `other` after |
|---|---|---|---|
| `Friends.INTEGRALE.MULTi.1080p.BluRay-GRP` | `Friends INTEGRALE` | `Friends` | `Complete` |
| `Friends.INTÉGRALE.MULTi.1080p.BluRay-GRP` | `Friends INTÉGRALE` | `Friends` | `Complete` |
| `Malcolm.LIntegrale.FRENCH.DVDRip-GRP` | `Malcolm LIntegrale` | `Malcolm` | `Complete`, `Rip` |
| `Malcolm.L'Integrale.FRENCH.DVDRip-GRP` | `Malcolm L'Integrale` | `Malcolm` | `Complete`, `Rip` |
| `Engrenages.Coffret.Integrale.FRENCH.1080p-GRP` | `Engrenages Coffret Integrale` | `Engrenages` | `Complete` |
| `Breaking.Bad.Integrale.Saison.1.FRENCH.1080p-GRP` | `Breaking Bad Integrale` | `Breaking Bad` | `Complete` (season 1 kept) |

## What changed

**The marker is configuration, not code.** Both `complete_words()` patterns hard-coded the literal
`Complete`; it now comes from `advanced_config.other.other._complete_words.complete_marker_words`,
alongside the `Int[ée]grale` spelling added to the `Complete` value itself. `Completa` (es/it),
`Komplett` (de) and friends are now a one-line addition rather than another rule.

**The French elided article needs its own pattern.** `L'Intégrale` is a single token (the
apostrophe is not a separator) and `Coffret Intégrale` puts a noun in front of the marker — neither
is anchored by a season word, so the existing article pattern rejects both. A third pattern matches
those prefixes, configured as `complete_prefix_words` and deliberately kept apart from
`complete_article_words`: `The` is ambiguous enough that `The complete movie` must stay a title,
which the corpus already pins.

**A latent bug surfaced while wiring this up** (first commit, independent of the rest). The article
group could open on the tail of a title word — the "the" of `Breathe.Complete.Series` — and the
match that grew from there was rejected by `seps_surround`. The scan then resumed *after* the
rejected span, so the real marker was never tried:

```
Breathe.Complete.Series.1080p-GRP -> title: 'Breathe Complete Series'   (no other)
Show.Complete.Series.1080p-GRP    -> title: 'Show', other: Complete
```

A lookbehind keeps the pattern from starting mid-word. Without it, adding the French `L` prefix
would have made the same failure much more common (every title word ending in `l`).

## Behaviour parity, and what is still out

`INTEGRALE` now behaves exactly like `COMPLETE`, including where `COMPLETE` itself gives up — the
`has-neighbor` tag needs an adjacent match, so an unrecognised French word in between still blocks
both equally:

```
Lost.Integrale.des.6.Saisons.FRENCH.720p-GRP -> title: 'Lost Integrale des 6 Saisons'
Lost.Complete.des.6.Saisons.FRENCH.720p-GRP  -> title: 'Lost Complete des 6 Saisons'
```

Same for `Kaamelott.Integrale.Livres.I.a.VI…`. Those are the `Complete` behaviour, not an
`INTEGRALE` gap, so they are left alone here.

Typing is untouched: a complete run still comes back as `type: movie` — that is #953, independent
of this one.

## Tests

- new corpus entries in `episodes.yml` (full release names, all spellings) and `rules/other.yml`
  (the marker on its own, plus the `Breathe` regression)
- full suite green (2511 passed), `pytest -m cross_parser` green, ruff + mypy clean
- diffed the **whole** YAML corpus before/after in `type=auto`, `type=movie` and `type=episode`:
  **0 divergence** on the 5751 existing results

🤖 Generated with [Claude Code](https://claude.com/claude-code)