### PR TITLE
feat(type): type a yearless complete run as an episode

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -313,6 +313,24 @@ downstream lookup against a real title database.
 The show *19-2* produces `19-2.2014`, which is a valid `DD-M.YYYY` date. A title that is itself a
 date-like number is structurally indistinguishable from an actual date; date detection wins.
 
+## A yearless `COMPLETE` film typed as a series
+
+```text
+The.Matrix.COMPLETE.BLURAY-GRP
+  type: episode                                           (#953)
+  wanted -> type: movie
+
+Lord.of.the.Rings.Trilogy.COMPLETE.BLURAY-GRP
+  type: episode                                           (#953)
+  wanted -> type: movie
+```
+
+`other: Complete` marks two unrelated things: a complete **run** of a series, and a complete
+**disc** of a film. The only local signal separating them is the year — a run spanning several
+years carries none, a film carries its own — so a yearless `COMPLETE` is read as a series. A film
+whose filename omits its release year, and a box set of films, therefore fall on the wrong side.
+Adding the year (`The.Matrix.1999.COMPLETE.BLURAY-GRP`) or `type=movie` settles it.
+
 ## How these could be revisited
 
 Most of the cases above share one root: they need to know whether an ambiguous token is *content*

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -597,7 +597,7 @@
         "Proof": {"string": "Proof", "tags": ["at-end", "not-a-release-group"]},
         "Obfuscated": {"string": ["Obfuscated", "Scrambled"], "tags": ["at-end", "not-a-release-group"]},
         "Repost": {"string": ["xpost", "postbot", "asrequested"], "tags": "not-a-release-group"},
-        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "complete_marker_words": ["Complete", "Int[ée]grale"], "season_words": ["seasons?", "series?"], "complete_article_words": ["The"], "complete_prefix_words": ["L['’]?", "Coffret"], "season_number_separators": ["&", "and"]}
+        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "complete_marker_words": ["Complete", "Int[ée]grale"], "season_words": ["seasons?", "mini-?series?", "series?"], "complete_article_words": ["The"], "complete_prefix_words": ["L['’]?", "Coffret"], "season_number_separators": ["&", "and"]}
       },
       "art": {
         "poster": "Poster",

--- a/guessit/rules/properties/type.py
+++ b/guessit/rules/properties/type.py
@@ -79,6 +79,14 @@ class TypeProcessor(CustomRule):
         if bonus and not year:
             return "episode"
 
+        # A complete run of a series spans several years and so carries none of its own, whereas a
+        # film on a complete disc carries its release year. The year is the only signal that tells
+        # the two apart, and neither half is a proof: a film whose name omits its year, or a box
+        # set of films, still lands on the episode side (#953).
+        complete = matches.named("other", lambda match: match.value == "Complete")
+        if complete and not year:
+            return "episode"
+
         crc32 = matches.named("crc32")
         anime_release_group = matches.named("release_group", lambda match: "anime" in match.tags)
         if crc32 and anime_release_group:

--- a/guessit/rules/properties/type.py
+++ b/guessit/rules/properties/type.py
@@ -28,6 +28,13 @@ def _type(matches: Matches, value: Any) -> None:
     matches.append(Match(len(matches.input_string), len(matches.input_string), name="type", value=value))
 
 
+def _is_complete_series(match: Match) -> bool:
+    """Whether ``match`` is a completeness marker qualified by a season word."""
+    return match.value == "Complete" and bool(
+        match.children.named("completeWordsBefore") or match.children.named("completeWordsAfter")
+    )
+
+
 def type_(config: dict[str, Any]) -> Rebulk:
     """
     Builder for rebulk object.
@@ -63,6 +70,12 @@ class TypeProcessor(CustomRule):
         episode_details = matches.named("episode_details")
 
         if episode or season or episode_details or absolute_episode:
+            return "episode"
+
+        # "COMPLETE SERIES", "COMPLETE MINISERIES": the season word next to the marker is consumed
+        # into it, so it reaches no property of its own — but a film is never a *series*, whatever
+        # else the name carries. This one holds even against a year, unlike a bare `Complete`.
+        if matches.named("other", predicate=_is_complete_series):
             return "episode"
 
         film = matches.named("film")

--- a/guessit/test/cross_parser/baseline.json
+++ b/guessit/test/cross_parser/baseline.json
@@ -299,11 +299,6 @@
     "thomas.and.friends.s19e09_s20e14.convert.hdtv.x264-w4f[eztv].mkv": [
       "season",
       "episode"
-    ],
-    "2012 2009 x264 720p Esub BluRay 6.0 Dual Audio English Hindi GOPISAHI": [
-      "title",
-      "year",
-      "video_codec"
     ]
   },
   "ptn": {
@@ -430,6 +425,12 @@
     "[Anime Time] Naruto - 116 - 360 Degrees of Vision The Byakugan's Blind Spot.mkv": [
       "episode"
     ],
+    "[JySzE] Naruto [v2] [R2J] [VFR] [Dual Audio] [Complete] [Extras] [x264]": [
+      "type"
+    ],
+    "[JySzE] Naruto [v3] [R2J] [VFR] [Dual Audio] [Complete] [Extras] [x264]": [
+      "type"
+    ],
     "Naruto Collection [DB 1080p][ Dual Audio ][ English & Arabic Sub ]": [
       "title"
     ],
@@ -467,6 +468,9 @@
     ],
     "xXx.2002.15th.Anniversary.Edition.1080p.BluRay.Remux.AVC.DTS-HD.MA.5.1-FraMeSToR": [
       "title"
+    ],
+    "Dragon Ball Z (Complete Series) [1080p] [MP4] [English Audio]": [
+      "type"
     ],
     "[GM-Team][国漫][太乙仙魔录 灵飞纪 第3季][Magical Legend of Rise to immortality Ⅲ][01-26][AVC][GB][1080P]": [
       "title"

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2046,6 +2046,25 @@
   release_group: GRP
   type: episode
 
+# A season word next to the marker outweighs the year: a film is never a *series*.
+? The.Wire.COMPLETE.SERIES.2002.720p.BluRay-GRP
+: title: The Wire
+  year: 2002
+  other: Complete
+  screen_size: 720p
+  source: Blu-ray
+  release_group: GRP
+  type: episode
+
+? Chernobyl.2019.COMPLETE.MINISERIES.1080p.WEB-GRP
+: title: Chernobyl
+  year: 2019
+  other: Complete
+  screen_size: 1080p
+  source: Web
+  release_group: GRP
+  type: episode
+
 ? Kampen Om Tungtvannet aka The Heavy Water War COMPLETE 720p x265 HEVC-Lund
 : title: Kampen Om Tungtvannet aka The Heavy Water War
   other: Complete

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2021,13 +2021,46 @@
   type: episode
   video_codec: H.264
 
+? Breaking.Bad.COMPLETE.1080p.BluRay.x264-GRP
+: title: Breaking Bad
+  other: Complete
+  screen_size: 1080p
+  source: Blu-ray
+  video_codec: H.264
+  release_group: GRP
+  type: episode
+
+? The.Wire.COMPLETE.SERIES.720p.BluRay-GRP
+: title: The Wire
+  other: Complete
+  screen_size: 720p
+  source: Blu-ray
+  release_group: GRP
+  type: episode
+
+? Chernobyl.COMPLETE.MINISERIES.1080p.WEB-GRP
+: title: Chernobyl
+  other: Complete
+  screen_size: 1080p
+  source: Web
+  release_group: GRP
+  type: episode
+
+? Kampen Om Tungtvannet aka The Heavy Water War COMPLETE 720p x265 HEVC-Lund
+: title: Kampen Om Tungtvannet aka The Heavy Water War
+  other: Complete
+  screen_size: 720p
+  video_codec: H.265
+  release_group: Lund
+  type: episode
+
 ? How.I.Met.Your.Mother.COMPLETE.SERIES.DVDRip.XviD-AR
 : options: -L en -C us
   source: DVD
   other: [Complete, Rip]
   release_group: AR
   title: How I Met Your Mother
-  type: movie # Should be episode
+  type: episode
   video_codec: Xvid
 
 ? Friends.INTEGRALE.MULTi.1080p.BluRay-GRP
@@ -2038,7 +2071,7 @@
   screen_size: 1080p
   source: Blu-ray
   release_group: GRP
-  type: movie # Should be episode, see #953
+  type: episode
 
 ? Malcolm.LIntegrale.FRENCH.DVDRip-GRP
 ? Malcolm.L'Integrale.FRENCH.DVDRip-GRP
@@ -2047,7 +2080,7 @@
   language: French
   source: DVD
   release_group: GRP
-  type: movie # Should be episode, see #953
+  type: episode
 
 ? Engrenages.Coffret.Integrale.FRENCH.1080p-GRP
 : title: Engrenages
@@ -2055,7 +2088,7 @@
   language: French
   screen_size: 1080p
   release_group: GRP
-  type: movie # Should be episode, see #953
+  type: episode
 
 ? Breaking.Bad.INTEGRALE.Saison.1.FRENCH.1080p-GRP
 : title: Breaking Bad

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1116,13 +1116,38 @@
   video_codec: H.264
   type: movie
 
-? Kampen Om Tungtvannet aka The Heavy Water War COMPLETE 720p x265 HEVC-Lund
-: title: Kampen Om Tungtvannet aka The Heavy Water War
+? The.Matrix.1999.COMPLETE.BLURAY-GRP
+: title: The Matrix
+  year: 1999
   other: Complete
-  screen_size: 720p
-  video_codec: H.265
-  release_group: Lund
+  source: Blu-ray
+  release_group: GRP
   type: movie
+
+? Heat.1995.COMPLETE.BLURAY.REMUX-GRP
+: title: Heat
+  year: 1995
+  other: [Complete, Remux]
+  source: Blu-ray
+  release_group: GRP
+  type: movie
+
+# The year is the only thing separating a film on a complete disc from a complete run of a
+# series. A film that does not carry its own year, and a box set of films, both fall on the
+# wrong side of that line.
+? The.Matrix.COMPLETE.BLURAY-GRP
+: title: The Matrix
+  other: Complete
+  source: Blu-ray
+  release_group: GRP
+  type: episode # Should be movie, no year to tell it from a complete run
+
+? Lord.of.the.Rings.Trilogy.COMPLETE.BLURAY-GRP
+: title: Lord of the Rings Trilogy
+  other: Complete
+  source: Blu-ray
+  release_group: GRP
+  type: episode # Should be movie, no year to tell it from a complete run
 
 ? All.Fall.Down.x264.PROOFFIX-OUTLAWS
 : title: All Fall Down


### PR DESCRIPTION
Closes #953.

`other: Complete` is emitted for two unrelated things — a complete **run** of a series and a
complete **disc** of a film — and auto-detection read neither, so every complete series pack came
back as `type: movie`.

The signal that separates them is already in the guess: **the year**. A film carries its own
release year; a run spanning several of them carries none. A yearless `Complete` now weighs
towards `episode`, in the same shape as the existing `date and not year` / `bonus and not year`
branches of `TypeProcessor`.

**6/16 → 16/16 on the sample of the issue:**

| name | truth | `type` before | `type` after |
|---|---|---|---|
| `Breaking.Bad.COMPLETE.1080p.BluRay.x264-GRP` | series | movie | **episode** |
| `Breaking.Bad.COMPLETE.SERIES.1080p-GRP` | series | movie | **episode** |
| `The.Wire.COMPLETE.SERIES.720p.BluRay-GRP` | series | movie | **episode** |
| `The.Sopranos.COMPLETE.1080p.BluRay.REMUX-GRP` | series | movie | **episode** |
| `Band.of.Brothers.COMPLETE.HDTV-GRP` | series | movie | **episode** |
| `Peaky.Blinders.COMPLETE.MULTi.1080p.WEB-GRP` | series | movie | **episode** |
| `Sons.of.Anarchy.COMPLETE.720p.BluRay.x264-GRP` | series | movie | **episode** |
| `Twin.Peaks.The.Entire.Mystery.COMPLETE.BLURAY-GRP` | series | movie | **episode** |
| `Planet.Earth.II.COMPLETE.2160p.UHD.BluRay-GRP` | series | movie | **episode** |
| `Chernobyl.COMPLETE.MINISERIES.1080p.WEB-GRP` | series | movie | **episode** |
| `The.Matrix.1999.COMPLETE.BLURAY-GRP` | movie | movie | movie |
| … the five other yeared films | movie | movie | movie |

## The MINISERIES asymmetry

`SERIES` was consumed next to the marker but `MINISERIES` was not, so `Chernobyl.COMPLETE.MINISERIES…`
returned title `Chernobyl COMPLETE MINISERIES` — a phantom second key for the same show. It joins
the configured season words (`advanced_config.other.other._complete_words.season_words`), so the
title is now `Chernobyl`.

## The trade-off, deliberately

Neither half of the year signal is a proof. A film whose filename omits its release year, and a box
set of films, are now typed `episode`:

```
The.Matrix.COMPLETE.BLURAY-GRP                -> type: episode   (wanted: movie)
Lord.of.the.Rings.Trilogy.COMPLETE.BLURAY-GRP -> type: episode   (wanted: movie)
```

This is the cost the issue anticipated. Both are pinned in `movies.yml` with a `# Should be movie`
comment and recorded in `docs/known-limitations.md`, so the compromise is visible rather than
folklore. Adding the year, or `type=movie`, settles either one.

## Tests

- diffed the **whole** YAML corpus before/after in `type=auto`, `type=movie` and `type=episode`:
  **16 divergences, all `movie` → `episode`, all of them corrections** — including
  `How.I.Met.Your.Mother.COMPLETE.SERIES.DVDRip.XviD-AR`, which the corpus already carried as
  `type: movie # Should be episode`, and `Kampen Om Tungtvannet aka The Heavy Water War COMPLETE…`
  (a Norwegian miniseries filed under `movies.yml`, moved to `episodes.yml`)
- new corpus entries on both sides of the year line, plus the `MINISERIES` title fix
- full suite green (2518 passed), ruff + mypy clean
- cross-parser baseline regenerated (`--baseline-only`): three new `type` disagreements recorded
  against `ptt`, all three on complete anime packs (`Naruto … [Complete]`, `Dragon Ball Z (Complete
  Series)`) where the imported label says `movie` and guessit now says `episode`. The regeneration
  also drops one stale entry that had already been fixed on `develop` before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)