### PR TITLE
release: v4.4.0

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -313,6 +313,24 @@ downstream lookup against a real title database.
 The show *19-2* produces `19-2.2014`, which is a valid `DD-M.YYYY` date. A title that is itself a
 date-like number is structurally indistinguishable from an actual date; date detection wins.
 
+## A yearless `COMPLETE` film typed as a series
+
+```text
+The.Matrix.COMPLETE.BLURAY-GRP
+  type: episode                                           (#953)
+  wanted -> type: movie
+
+Lord.of.the.Rings.Trilogy.COMPLETE.BLURAY-GRP
+  type: episode                                           (#953)
+  wanted -> type: movie
+```
+
+`other: Complete` marks two unrelated things: a complete **run** of a series, and a complete
+**disc** of a film. The only local signal separating them is the year — a run spanning several
+years carries none, a film carries its own — so a yearless `COMPLETE` is read as a series. A film
+whose filename omits its release year, and a box set of films, therefore fall on the wrong side.
+Adding the year (`The.Matrix.1999.COMPLETE.BLURAY-GRP`) or `type=movie` settles it.
+
 ## How these could be revisited
 
 Most of the cases above share one root: they need to know whether an ambiguous token is *content*

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -597,7 +597,7 @@
         "Proof": {"string": "Proof", "tags": ["at-end", "not-a-release-group"]},
         "Obfuscated": {"string": ["Obfuscated", "Scrambled"], "tags": ["at-end", "not-a-release-group"]},
         "Repost": {"string": ["xpost", "postbot", "asrequested"], "tags": "not-a-release-group"},
-        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "complete_marker_words": ["Complete", "Int[ée]grale"], "season_words": ["seasons?", "series?"], "complete_article_words": ["The"], "complete_prefix_words": ["L['’]?", "Coffret"], "season_number_separators": ["&", "and"]}
+        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "complete_marker_words": ["Complete", "Int[ée]grale"], "season_words": ["seasons?", "mini-?series?", "series?"], "complete_article_words": ["The"], "complete_prefix_words": ["L['’]?", "Coffret"], "season_number_separators": ["&", "and"]}
       },
       "art": {
         "poster": "Poster",

--- a/guessit/config/options.json
+++ b/guessit/config/options.json
@@ -560,7 +560,10 @@
         "Full HD": {"string": ["FHD"],"regex": ["Full-?HD"], "validator": null, "tags": ["streaming_service.prefix", "streaming_service.suffix"]},
         "Ultra HD": {"string": ["UHD"],"regex": ["Ultra-?(?:HD)?"], "validator": null, "tags": ["streaming_service.prefix", "streaming_service.suffix"]},
         "Upscaled": {"regex": "Upscaled?"},
-        "Complete": {"string": ["Complet", "Complete"], "tags": ["has-neighbor", "release-group-prefix"]},
+        "Complete": [
+          {"string": ["Complet", "Complete"], "tags": ["has-neighbor", "release-group-prefix"]},
+          {"regex": ["Int[ée]grale"], "tags": ["has-neighbor", "release-group-prefix"]}
+        ],
         "Classic": {"string": "Classic", "tags": ["has-neighbor", "release-group-prefix"]},
         "Bonus": {"string": "Bonus", "tags": ["has-neighbor", "release-group-prefix"]},
         "Trailer": {"string": "Trailer", "tags": ["has-neighbor", "release-group-prefix"]},
@@ -594,7 +597,7 @@
         "Proof": {"string": "Proof", "tags": ["at-end", "not-a-release-group"]},
         "Obfuscated": {"string": ["Obfuscated", "Scrambled"], "tags": ["at-end", "not-a-release-group"]},
         "Repost": {"string": ["xpost", "postbot", "asrequested"], "tags": "not-a-release-group"},
-        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "season_words": ["seasons?", "series?"], "complete_article_words": ["The"], "season_number_separators": ["&", "and"]}
+        "_complete_words": {"callable": "import:guessit.rules.properties.other:complete_words", "complete_marker_words": ["Complete", "Int[ée]grale"], "season_words": ["seasons?", "series?"], "complete_article_words": ["The"], "complete_prefix_words": ["L['’]?", "Coffret"], "season_number_separators": ["&", "and"]}
       },
       "art": {
         "poster": "Poster",

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -151,16 +151,23 @@ _TOKEN_START = r"(?<![^\W_])"
 
 def complete_words(
     rebulk: Rebulk,
+    complete_marker_words: Iterable[str],
     season_words: Iterable[str],
     complete_article_words: Iterable[str],
+    complete_prefix_words: Iterable[str],
     season_number_separators: Iterable[str],
 ) -> None:
     """
     Custom pattern to find complete seasons from words.
 
-    ``season_number_separators`` are the tokens that may join the season numbers a marker spans,
-    e.g. the ``&`` of "Seasons 1 & 2 - Complete"; plain separators are always allowed.
+    ``complete_marker_words`` are the completeness markers themselves, ``Complete`` and its
+    equivalents in other languages. ``complete_article_words`` only qualify a marker that a season
+    word already anchors ("The Complete Series"), whereas ``complete_prefix_words`` carry the
+    completeness on their own ("L'Intégrale", "Coffret Intégrale"). ``season_number_separators``
+    are the tokens that may join the season numbers a marker spans, e.g. the ``&`` of
+    "Seasons 1 & 2 - Complete"; plain separators are always allowed.
     """
+    complete_marker_pattern = build_or_pattern(complete_marker_words)
     season_words_pattern = build_or_pattern(season_words)
     complete_article_words_pattern = build_or_pattern(complete_article_words)
     # The season numbers listed between the season word and the marker: "1", "1 & 2", "1 and 2".
@@ -185,7 +192,7 @@ def complete_words(
         + "(?P<completeWordsBefore>"
         + season_words_pattern
         + "-)?"
-        + "Complete"
+        + complete_marker_pattern
         + "(?P<completeWordsAfter>-"
         + season_words_pattern
         + ")?",
@@ -200,10 +207,26 @@ def complete_words(
     # numbered season word keeps the marker alive even when nothing matched the numbers — the
     # season chain is off under a forced ``type=movie`` (#944).
     rebulk.regex(
-        season_words_pattern + season_numbers_pattern + "(?P<other>Complete)",
+        season_words_pattern + season_numbers_pattern + "(?P<other>" + complete_marker_pattern + ")",
         children=True,
         private_parent=True,
         validate_all=True,
+        value={"other": "Complete"},
+        tags=["release-group-prefix"],
+        validator={"__parent__": seps_surround},
+    )
+
+    # "L'Intégrale", "Coffret Intégrale": the prefix carries the completeness with no season word
+    # to anchor on, so the first pattern rejects it. The separator is optional because the French
+    # elided article glues to the marker — the apostrophe is not a separator, so "L'Intégrale" is
+    # a single token that has to be matched whole for the marker to leave the title.
+    rebulk.regex(
+        _TOKEN_START
+        + "(?P<completePrefix>"
+        + build_or_pattern(complete_prefix_words)
+        + "-?)"
+        + complete_marker_pattern,
+        private_names=["completePrefix"],
         value={"other": "Complete"},
         tags=["release-group-prefix"],
         validator={"__parent__": seps_surround},

--- a/guessit/rules/properties/other.py
+++ b/guessit/rules/properties/other.py
@@ -142,6 +142,13 @@ def opening_ending_credits(rebulk: Rebulk) -> None:
     add(r"ED", "Ending Credits", ignore_case=False)
 
 
+#: A match may only start on a token boundary. Without it a leading word part is a valid starting
+#: point for the regex — the "the" of "Breathe.Complete.Series" opens an article group — and the
+#: whole match is then dropped by ``seps_surround``, taking the real marker down with it: the
+#: scan resumes *after* the rejected span, so "Complete.Series" is never tried.
+_TOKEN_START = r"(?<![^\W_])"
+
+
 def complete_words(
     rebulk: Rebulk,
     season_words: Iterable[str],
@@ -171,7 +178,8 @@ def complete_words(
         return not (not children.named("completeWordsBefore") and not children.named("completeWordsAfter"))
 
     rebulk.regex(
-        "(?P<completeArticle>"
+        _TOKEN_START
+        + "(?P<completeArticle>"
         + complete_article_words_pattern
         + "-)?"
         + "(?P<completeWordsBefore>"

--- a/guessit/rules/properties/type.py
+++ b/guessit/rules/properties/type.py
@@ -79,6 +79,14 @@ class TypeProcessor(CustomRule):
         if bonus and not year:
             return "episode"
 
+        # A complete run of a series spans several years and so carries none of its own, whereas a
+        # film on a complete disc carries its release year. The year is the only signal that tells
+        # the two apart, and neither half is a proof: a film whose name omits its year, or a box
+        # set of films, still lands on the episode side (#953).
+        complete = matches.named("other", lambda match: match.value == "Complete")
+        if complete and not year:
+            return "episode"
+
         crc32 = matches.named("crc32")
         anime_release_group = matches.named("release_group", lambda match: "anime" in match.tags)
         if crc32 and anime_release_group:

--- a/guessit/rules/properties/type.py
+++ b/guessit/rules/properties/type.py
@@ -28,6 +28,13 @@ def _type(matches: Matches, value: Any) -> None:
     matches.append(Match(len(matches.input_string), len(matches.input_string), name="type", value=value))
 
 
+def _is_complete_series(match: Match) -> bool:
+    """Whether ``match`` is a completeness marker qualified by a season word."""
+    return match.value == "Complete" and bool(
+        match.children.named("completeWordsBefore") or match.children.named("completeWordsAfter")
+    )
+
+
 def type_(config: dict[str, Any]) -> Rebulk:
     """
     Builder for rebulk object.
@@ -63,6 +70,12 @@ class TypeProcessor(CustomRule):
         episode_details = matches.named("episode_details")
 
         if episode or season or episode_details or absolute_episode:
+            return "episode"
+
+        # "COMPLETE SERIES", "COMPLETE MINISERIES": the season word next to the marker is consumed
+        # into it, so it reaches no property of its own — but a film is never a *series*, whatever
+        # else the name carries. This one holds even against a year, unlike a bare `Complete`.
+        if matches.named("other", predicate=_is_complete_series):
             return "episode"
 
         film = matches.named("film")

--- a/guessit/test/cross_parser/baseline.json
+++ b/guessit/test/cross_parser/baseline.json
@@ -299,11 +299,6 @@
     "thomas.and.friends.s19e09_s20e14.convert.hdtv.x264-w4f[eztv].mkv": [
       "season",
       "episode"
-    ],
-    "2012 2009 x264 720p Esub BluRay 6.0 Dual Audio English Hindi GOPISAHI": [
-      "title",
-      "year",
-      "video_codec"
     ]
   },
   "ptn": {
@@ -430,6 +425,12 @@
     "[Anime Time] Naruto - 116 - 360 Degrees of Vision The Byakugan's Blind Spot.mkv": [
       "episode"
     ],
+    "[JySzE] Naruto [v2] [R2J] [VFR] [Dual Audio] [Complete] [Extras] [x264]": [
+      "type"
+    ],
+    "[JySzE] Naruto [v3] [R2J] [VFR] [Dual Audio] [Complete] [Extras] [x264]": [
+      "type"
+    ],
     "Naruto Collection [DB 1080p][ Dual Audio ][ English & Arabic Sub ]": [
       "title"
     ],
@@ -467,6 +468,9 @@
     ],
     "xXx.2002.15th.Anniversary.Edition.1080p.BluRay.Remux.AVC.DTS-HD.MA.5.1-FraMeSToR": [
       "title"
+    ],
+    "Dragon Ball Z (Complete Series) [1080p] [MP4] [English Audio]": [
+      "type"
     ],
     "[GM-Team][国漫][太乙仙魔录 灵飞纪 第3季][Magical Legend of Rise to immortality Ⅲ][01-26][AVC][GB][1080P]": [
       "title"

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2030,6 +2030,42 @@
   type: movie # Should be episode
   video_codec: Xvid
 
+? Friends.INTEGRALE.MULTi.1080p.BluRay-GRP
+? Friends.INTÉGRALE.MULTi.1080p.BluRay-GRP
+: title: Friends
+  other: Complete
+  language: mul
+  screen_size: 1080p
+  source: Blu-ray
+  release_group: GRP
+  type: movie # Should be episode, see #953
+
+? Malcolm.LIntegrale.FRENCH.DVDRip-GRP
+? Malcolm.L'Integrale.FRENCH.DVDRip-GRP
+: title: Malcolm
+  other: [Complete, Rip]
+  language: French
+  source: DVD
+  release_group: GRP
+  type: movie # Should be episode, see #953
+
+? Engrenages.Coffret.Integrale.FRENCH.1080p-GRP
+: title: Engrenages
+  other: Complete
+  language: French
+  screen_size: 1080p
+  release_group: GRP
+  type: movie # Should be episode, see #953
+
+? Breaking.Bad.INTEGRALE.Saison.1.FRENCH.1080p-GRP
+: title: Breaking Bad
+  other: Complete
+  season: 1
+  language: French
+  screen_size: 1080p
+  release_group: GRP
+  type: episode
+
 ? Show Name The Complete Seasons 1 to 5 720p BluRay x265 HEVC-SUJAIDR[UTR]
 : source: Blu-ray
   other: Complete

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2046,6 +2046,25 @@
   release_group: GRP
   type: episode
 
+# A season word next to the marker outweighs the year: a film is never a *series*.
+? The.Wire.COMPLETE.SERIES.2002.720p.BluRay-GRP
+: title: The Wire
+  year: 2002
+  other: Complete
+  screen_size: 720p
+  source: Blu-ray
+  release_group: GRP
+  type: episode
+
+? Chernobyl.2019.COMPLETE.MINISERIES.1080p.WEB-GRP
+: title: Chernobyl
+  year: 2019
+  other: Complete
+  screen_size: 1080p
+  source: Web
+  release_group: GRP
+  type: episode
+
 ? Kampen Om Tungtvannet aka The Heavy Water War COMPLETE 720p x265 HEVC-Lund
 : title: Kampen Om Tungtvannet aka The Heavy Water War
   other: Complete

--- a/guessit/test/episodes.yml
+++ b/guessit/test/episodes.yml
@@ -2021,13 +2021,46 @@
   type: episode
   video_codec: H.264
 
+? Breaking.Bad.COMPLETE.1080p.BluRay.x264-GRP
+: title: Breaking Bad
+  other: Complete
+  screen_size: 1080p
+  source: Blu-ray
+  video_codec: H.264
+  release_group: GRP
+  type: episode
+
+? The.Wire.COMPLETE.SERIES.720p.BluRay-GRP
+: title: The Wire
+  other: Complete
+  screen_size: 720p
+  source: Blu-ray
+  release_group: GRP
+  type: episode
+
+? Chernobyl.COMPLETE.MINISERIES.1080p.WEB-GRP
+: title: Chernobyl
+  other: Complete
+  screen_size: 1080p
+  source: Web
+  release_group: GRP
+  type: episode
+
+? Kampen Om Tungtvannet aka The Heavy Water War COMPLETE 720p x265 HEVC-Lund
+: title: Kampen Om Tungtvannet aka The Heavy Water War
+  other: Complete
+  screen_size: 720p
+  video_codec: H.265
+  release_group: Lund
+  type: episode
+
 ? How.I.Met.Your.Mother.COMPLETE.SERIES.DVDRip.XviD-AR
 : options: -L en -C us
   source: DVD
   other: [Complete, Rip]
   release_group: AR
   title: How I Met Your Mother
-  type: movie # Should be episode
+  type: episode
   video_codec: Xvid
 
 ? Friends.INTEGRALE.MULTi.1080p.BluRay-GRP
@@ -2038,7 +2071,7 @@
   screen_size: 1080p
   source: Blu-ray
   release_group: GRP
-  type: movie # Should be episode, see #953
+  type: episode
 
 ? Malcolm.LIntegrale.FRENCH.DVDRip-GRP
 ? Malcolm.L'Integrale.FRENCH.DVDRip-GRP
@@ -2047,7 +2080,7 @@
   language: French
   source: DVD
   release_group: GRP
-  type: movie # Should be episode, see #953
+  type: episode
 
 ? Engrenages.Coffret.Integrale.FRENCH.1080p-GRP
 : title: Engrenages
@@ -2055,7 +2088,7 @@
   language: French
   screen_size: 1080p
   release_group: GRP
-  type: movie # Should be episode, see #953
+  type: episode
 
 ? Breaking.Bad.INTEGRALE.Saison.1.FRENCH.1080p-GRP
 : title: Breaking Bad

--- a/guessit/test/movies.yml
+++ b/guessit/test/movies.yml
@@ -1116,13 +1116,38 @@
   video_codec: H.264
   type: movie
 
-? Kampen Om Tungtvannet aka The Heavy Water War COMPLETE 720p x265 HEVC-Lund
-: title: Kampen Om Tungtvannet aka The Heavy Water War
+? The.Matrix.1999.COMPLETE.BLURAY-GRP
+: title: The Matrix
+  year: 1999
   other: Complete
-  screen_size: 720p
-  video_codec: H.265
-  release_group: Lund
+  source: Blu-ray
+  release_group: GRP
   type: movie
+
+? Heat.1995.COMPLETE.BLURAY.REMUX-GRP
+: title: Heat
+  year: 1995
+  other: [Complete, Remux]
+  source: Blu-ray
+  release_group: GRP
+  type: movie
+
+# The year is the only thing separating a film on a complete disc from a complete run of a
+# series. A film that does not carry its own year, and a box set of films, both fall on the
+# wrong side of that line.
+? The.Matrix.COMPLETE.BLURAY-GRP
+: title: The Matrix
+  other: Complete
+  source: Blu-ray
+  release_group: GRP
+  type: episode # Should be movie, no year to tell it from a complete run
+
+? Lord.of.the.Rings.Trilogy.COMPLETE.BLURAY-GRP
+: title: Lord of the Rings Trilogy
+  other: Complete
+  source: Blu-ray
+  release_group: GRP
+  type: episode # Should be movie, no year to tell it from a complete run
 
 ? All.Fall.Down.x264.PROOFFIX-OUTLAWS
 : title: All Fall Down

--- a/guessit/test/rules/other.yml
+++ b/guessit/test/rules/other.yml
@@ -134,6 +134,15 @@
 ? +The complete movie
 : title: The complete movie
 
+? INTEGRALE 1080p
+? INTÉGRALE 1080p
+? Integrale 1080p
+? L'Integrale 1080p
+? LIntegrale 1080p
+? L.Integrale.1080p
+? Coffret Integrale 1080p
+: other: Complete
+
 # A leading word part must not open the article group: the "the" of "Breathe" used to swallow
 # the whole match, and the marker went down with it.
 ? Breathe.Complete.Series.1080p-GRP

--- a/guessit/test/rules/other.yml
+++ b/guessit/test/rules/other.yml
@@ -134,6 +134,12 @@
 ? +The complete movie
 : title: The complete movie
 
+# A leading word part must not open the article group: the "the" of "Breathe" used to swallow
+# the whole match, and the marker went down with it.
+? Breathe.Complete.Series.1080p-GRP
+: other: Complete
+  title: Breathe
+
 ? +AC3-HQ
 : audio_profile: High Quality
 


### PR DESCRIPTION
Release `develop` → `main`, cutting **v4.4.0** (minor — two `feat`, one `fix`, no breaking change).

### Features

- **`feat(other)`** — read the French `INTEGRALE` as a complete run (#954). The marker is now
  configuration rather than code (`complete_marker_words`), so other languages are a one-line
  addition; `L'Intégrale` / `Coffret Intégrale` are handled via `complete_prefix_words`.
- **`feat(type)`** — a yearless `Complete` is typed `episode` instead of `movie` (#953): a complete
  run of a series carries no year of its own, a film on a complete disc carries its release year.
  `COMPLETE SERIES` / `COMPLETE MINISERIES` outweigh the year outright, since a film is never a
  series. `MINISERIES` also stops leaking into the title.

### Fixes

- **`fix(other)`** — anchor the complete marker on a token boundary: the article group could open on
  the tail of a title word (the "the" of `Breathe.Complete.Series`), and the rejected match took the
  real marker down with it.

### Notes

- Behaviour change worth flagging for consumers: complete series packs now come back as
  `type: episode`. The known trade-off — a film whose filename omits its year, and box sets of films
  — is recorded in `docs/known-limitations.md`.
- Cross-parser baseline regenerated; three new `type` disagreements against `ptt`, all on complete
  anime packs where guessit is now the more accurate of the two.

Merge as a **merge commit** (never squash).