### PR TITLE
fix: make both RemoveLessSpecificSeasonEpisode passes execute (#961)

### DIFF
--- a/guessit/rules/processors.py
+++ b/guessit/rules/processors.py
@@ -164,6 +164,44 @@ class RemoveLessSpecificSeasonEpisode(RemoveAmbiguous):
             predicate=lambda match: match.name == name,
         )
 
+    def when(self, matches: Matches, context: dict[str, Any] | None) -> Any:
+        # Only decide when the SxxExx weights strictly differ. Equally-specific fileparts
+        # ("S06E01.E10" pack dir vs "S06E09" file) are left to the generic RemoveAmbiguous,
+        # whose full-property weight and rightmost preference pick the correct side.
+        def sxx_exx(match: Match) -> bool:
+            return match.name in ("season", "episode") and "SxxExx" in match.tags
+
+        markers = matches.markers.named("path")
+        if len(markers) > 1:
+            weights = [
+                len({match.name for match in matches.range(marker.start, marker.end, predicate=sxx_exx)})
+                for marker in markers
+            ]
+            top = max(weights)
+            if weights.count(top) > 1:
+                return []
+        return super().when(matches, context)
+
+
+class RemoveLessSpecificSeason(RemoveLessSpecificSeasonEpisode):
+    """
+    Distinct subclass so both season and episode passes survive rule registration: rebulk's
+    ``Rule.__eq__``/``__hash__`` compare by class only, so two instances of the same class are
+    deduplicated by ``extend_safe`` when rebulk objects are merged and only the first one executes.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("season")
+
+
+class RemoveLessSpecificEpisode(RemoveLessSpecificSeasonEpisode):
+    """
+    See :class:`RemoveLessSpecificSeason`.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("episode")
+
 
 def _preferred_string(value1: str, value2: str) -> str:
     """
@@ -288,8 +326,8 @@ def processors(config: dict[str, Any]) -> Rebulk:
     return Rebulk().rules(
         EnlargeGroupMatches,
         EquivalentHoles,
-        RemoveLessSpecificSeasonEpisode("season"),
-        RemoveLessSpecificSeasonEpisode("episode"),
+        RemoveLessSpecificSeason,
+        RemoveLessSpecificEpisode,
         RemoveAmbiguous,
         SeasonYear,
         YearSeason,


### PR DESCRIPTION
Fixes #961.

## Problem

`processors.py` registers the same rule class twice:

```python
RemoveLessSpecificSeasonEpisode("season"),
RemoveLessSpecificSeasonEpisode("episode"),
```

but rebulk's `Rule.__eq__`/`__hash__` compare by class only, so when rebulk objects are merged (`extend_safe` in `effective_rules()`) the second instance is silently dropped. Only the `("season")` pass has ever executed; the `("episode")` pass is dead code. Verifiable on 4.4.0:

```python
from guessit.api import default_api
default_api.guessit('warmup.mkv')
rules = [r for r in default_api.rebulk.effective_rules()
         if type(r).__name__ == 'RemoveLessSpecificSeasonEpisode']
len(rules)  # -> 1, and its predicate closes over "season"
```

## Fix

- Registration split into two distinct subclasses, `RemoveLessSpecificSeason` and `RemoveLessSpecificEpisode`, so both passes survive dedup.
- Reviving the episode pass exposed one regression in the existing corpus (`The.Good.Wife.S06E01.E10.…/The.Good.Wife.S06E09.….mkv` — the pack directory's `[1, 10]` overrode the file's episode 9), so the rule now acts only when one filepart is strictly more SxxExx-specific than the others; equally-specific fileparts fall through to the generic `RemoveAmbiguous`, whose full-property weight and rightmost preference already pick the correct side.

Same fix shipped in [guessit-js](https://github.com/opensubtitles/guessit-js) (TypeScript port tracking this corpus) where we originally hit the trap.

## Tests

Full suite: **2520 passed, 4 skipped** (was 1 failure with the naive two-subclass fix, 0 with the specificity guard).
